### PR TITLE
Return date of cached response

### DIFF
--- a/requests_cache/core.py
+++ b/requests_cache/core.py
@@ -39,7 +39,7 @@ class CachedSession(OriginalSession):
                            e.g ``cache.sqlite``
 
                            for ``mongodb``: it's used as database name
-                           
+
                            for ``redis``: it's used as the namespace. This means all keys
                            are prefixed with ``'cache_name:'``
         :param backend: cache backend name e.g ``'sqlite'``, ``'mongodb'``, ``'redis'``, ``'memory'``.
@@ -54,7 +54,7 @@ class CachedSession(OriginalSession):
         :param allowable_methods: cache only requests of this methods (default: 'GET')
         :type allowable_methods: tuple
         :kwarg backend_options: options for chosen backend. See corresponding
-                                :ref:`sqlite <backends_sqlite>`, :ref:`mongo <backends_mongo>` 
+                                :ref:`sqlite <backends_sqlite>`, :ref:`mongo <backends_mongo>`
                                 and :ref:`redis <backends_redis>` backends API documentation
         """
         if backend is None or isinstance(backend, basestring):
@@ -74,6 +74,7 @@ class CachedSession(OriginalSession):
             or request.method not in self._cache_allowable_methods):
             response = super(CachedSession, self).send(request, **kwargs)
             response.from_cache = False
+            response.cache_date = None
             return response
 
         cache_key = self.cache.create_key(request)
@@ -83,6 +84,7 @@ class CachedSession(OriginalSession):
             if response.status_code in self._cache_allowable_codes:
                 self.cache.save_response(cache_key, response)
             response.from_cache = False
+            response.cache_date = None
             return response
 
         response, timestamp = self.cache.get_response_and_time(cache_key)
@@ -96,6 +98,7 @@ class CachedSession(OriginalSession):
                 return send_request_and_cache_response()
         # dispatch hook here, because we've removed it before pickling
         response.from_cache = True
+        response.cache_date = timestamp
         response = dispatch_hook('response', request.hooks, response, **kwargs)
         return response
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -15,6 +15,7 @@ from requests import Request
 import requests_cache
 from requests_cache import CachedSession
 from requests_cache.compat import bytes, str, is_py3
+import datetime
 
 CACHE_BACKEND = 'sqlite'
 CACHE_NAME = 'requests_cache_test'
@@ -247,6 +248,15 @@ class CacheTestCase(unittest.TestCase):
         url = httpbin('gzip')
         self.assertFalse(self.s.get(url).from_cache)
         self.assertTrue(self.s.get(url).from_cache)
+
+    def test_cache_date(self):
+        url = httpbin('get')
+        response1 = self.s.get(url)
+        response2 = self.s.get(url)
+        response3 = self.s.get(url)
+        self.assertEqual(response1.cache_date, None)
+        self.assertTrue(isinstance(response2.cache_date, datetime.datetime))
+        self.assertEqual(response2.cache_date, response3.cache_date)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I'm in a position where I'm wanting to be able to know how stale a cached item is: I don't know whether this is a pull request you'd be interested in including or not.

Obviously `cache_date` needs documenting before being accepted; I'm also not certain about the name of the attribute itself.

Any thoughts?
