### PR TITLE
Add required _Store.release_conn() method

### DIFF
--- a/requests_cache/backends/base.py
+++ b/requests_cache/backends/base.py
@@ -162,7 +162,8 @@ class BaseCache(object):
 
 # used for saving response attributes
 class _Store(object):
-    pass
+    def release_conn(self):
+        pass
 
 
 def _to_bytes(s, encoding='utf-8'):


### PR DESCRIPTION
As witnessed using requests==2.3.0:

```
  File "harvest.py", line 59, in fetch_uri
    r = requests.get(url, headers=headers, timeout=TIMEOUT)
  File "/usr/local/lib/python2.7/dist-packages/requests/api.py", line 55, in get
    return request('get', url, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/requests/api.py", line 44, in request
    return session.request(method=method, url=url, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/requests_cache/core.py", line 110, in request
    hooks, stream, verify, cert)
  File "/usr/local/lib/python2.7/dist-packages/requests/sessions.py", line 456, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python2.7/dist-packages/requests_cache/core.py", line 90, in send
    return send_request_and_cache_response()
  File "/usr/local/lib/python2.7/dist-packages/requests_cache/core.py", line 82, in send_request_and_cache_response
    response = super(CachedSession, self).send(request, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/requests/sessions.py", line 585, in send
    history = [resp for resp in gen] if allow_redirects else []
  File "/usr/local/lib/python2.7/dist-packages/requests/sessions.py", line 107, in resolve_redirects
    resp.close()
  File "/usr/local/lib/python2.7/dist-packages/requests/models.py", line 803, in close
    return self.raw.release_conn()
AttributeError: '_Store' object has no attribute 'release_conn'
```
