### PR TITLE
Better transactional handling in sqlite

### DIFF
--- a/requests_cache/backends/storage/dbdict.py
+++ b/requests_cache/backends/storage/dbdict.py
@@ -6,7 +6,6 @@
 
     Dictionary-like objects for saving large data sets to `sqlite` database
 """
-import logging
 from collections import MutableMapping
 import sqlite3 as sqlite
 from contextlib import contextmanager
@@ -48,10 +47,6 @@ class DbDict(MutableMapping):
         self.filename = filename
         self.table_name = table_name
         self.fast_save = fast_save
-        
-        if self.fast_save:
-            logger = logging.getLogger(__name__)
-            logger.debug('Fast Saves for sqlite')
         
         #: Transactions can be commited if this property is set to `True`
         self.can_commit = True

--- a/requests_cache/backends/storage/dbdict.py
+++ b/requests_cache/backends/storage/dbdict.py
@@ -6,11 +6,12 @@
 
     Dictionary-like objects for saving large data sets to `sqlite` database
 """
+import logging
 from collections import MutableMapping
 import sqlite3 as sqlite
 from contextlib import contextmanager
 try:
-   import threading
+    import threading
 except ImportError:
     import dummy_threading as threading
 try:
@@ -19,7 +20,6 @@ except ImportError:
     import pickle
 
 from requests_cache.compat import bytes
-
 
 
 class DbDict(MutableMapping):
@@ -48,6 +48,10 @@ class DbDict(MutableMapping):
         self.filename = filename
         self.table_name = table_name
         self.fast_save = fast_save
+        
+        if self.fast_save:
+            logger = logging.getLogger(__name__)
+            logger.debug('Fast Saves for sqlite')
         
         #: Transactions can be commited if this property is set to `True`
         self.can_commit = True
@@ -122,21 +126,14 @@ class DbDict(MutableMapping):
 
     def __setitem__(self, key, item):
         with self.connection(True) as con:
-            if con.execute("select key from `%s` where key=?" %
-                           self.table_name, (key,)).fetchone():
-                con.execute("update `%s` set value=? where key=?" %
-                            self.table_name, (item, key))
-            else:
-                con.execute("insert into `%s` (key,value) values (?,?)" %
-                            self.table_name, (key, item))
+            con.execute("insert or replace into `%s` (key,value) values (?,?)" %
+                        self.table_name, (key, item))
 
     def __delitem__(self, key):
         with self.connection(True) as con:
-            if con.execute("select key from `%s` where key=?" %
-                           self.table_name, (key,)).fetchone():
-                con.execute("delete from `%s` where key=?" %
-                            self.table_name, (key,))
-            else:
+            cur = con.execute("delete from `%s` where key=?" %
+                              self.table_name, (key,))
+            if not cur.rowcount:
                 raise KeyError
 
     def __iter__(self):
@@ -148,7 +145,7 @@ class DbDict(MutableMapping):
     def __len__(self):
         with self.connection() as con:
             return con.execute("select count(key) from `%s`" %
-                                self.table_name).fetchone()[0]
+                               self.table_name).fetchone()[0]
 
     def clear(self):
         with self.connection(True) as con:

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     packages=['requests_cache',
               'requests_cache.backends',
               'requests_cache.backends.storage'],
-    version='0.4.9',
+    version='0.4.10',
     description='Persistent cache for requests library',
     author='Roman Haritonov',
     author_email='reclosedev@gmail.com',


### PR DESCRIPTION
With my application I found many "IntegrityError: column key is not unique" errors. This is because the select statement inside of `__setitem__` wasn't in a transaction with the insert/update. So some other process could come along and add the key between the two statement. Rather than use a transaction I switched to using the "insert or replace into" statement which handles both cases effectively. Also updated `__delitem__` since that one could suffer from a similar problem.