### PR TITLE
Adding `ignored_parameters` feature

### DIFF
--- a/requests_cache/core.py
+++ b/requests_cache/core.py
@@ -6,6 +6,7 @@
 
     Core functions for configuring cache and monkey patching ``requests``
 """
+import collections
 from contextlib import contextmanager
 from datetime import datetime, timedelta
 from operator import itemgetter
@@ -264,17 +265,19 @@ def clear():
 def _patch_session_factory(session_factory=CachedSession):
     requests.Session = requests.sessions.Session = session_factory
 
-def _normalize_parameters(params, ignored_parameters=None):
+
+def _normalize_parameters(params, ignored_params=None):
     """ If builtin dict is passed as parameter, returns sorted list
     of key-value pairs
     """
     if type(params) is dict:
         params = sorted(params.items(), key=itemgetter(0))
+    elif isinstance(params, collections.Mapping):
+        params = params.items()
 
-    if ignored_parameters:
+    if ignored_params:
         try:
-            params = [(key, value) for key, value in params \
-                    if key not in ignored_parameters]
+            params = [(k, v) for k, v in params if k not in ignored_params]
         except (AttributeError, ValueError, TypeError):
             pass
     return params

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -362,6 +362,21 @@ class CacheTestCase(unittest.TestCase):
             with self.assertRaises(Exception):
                 s.get(url)
 
+    def test_ignore_parameters(self):
+        url = httpbin("get")
+        ignored_param = "ignored"
+        usual_param = "some"
+        s = CachedSession(CACHE_NAME, CACHE_BACKEND, ignored_parameters=[ignored_param])
+
+        params = {ignored_param: "1", usual_param: "1"}
+        s.get(url, params=params)
+        self.assertTrue(s.get(url, params=params).from_cache)
+
+        params[ignored_param] = "new"
+        self.assertTrue(s.get(url, params=params).from_cache)
+
+        params[usual_param] = "new"
+        self.assertFalse(s.get(url, params=params).from_cache)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This pull request adds the possibility to exclude some request parameters from the cache key. This is useful in some occasions, for example when requesting the same resources with more access tokens, specified as parameters.

Please let me know if this needs any change to be included in the original project.