### PR TITLE
More informative message for missing backend dependencies

### DIFF
--- a/requests_cache/backends/__init__.py
+++ b/requests_cache/backends/__init__.py
@@ -14,6 +14,12 @@ registry = {
     'memory': BaseCache,
 }
 
+_backend_dependencies = {
+    'sqlite': 'sqlite3',
+    'mongo': 'pymongo',
+    'redis': 'redis'
+}
+
 try:
     # Heroku doesn't allow the SQLite3 module to be installed
     from .sqlite import DbCache
@@ -40,11 +46,16 @@ def create_backend(backend_name, cache_name, options):
     try:
         return registry[backend_name](cache_name, **options)
     except KeyError:
-        raise ValueError('Unsupported backend "%s" try one of: %s' %
-                         (backend_name, ', '.join(registry.keys())))
+        if backend_name in _backend_dependencies:
+            raise ImportError('You must install the python package: %s' %
+                             _backend_dependencies[backend_name])
+        else:
+            raise ValueError('Unsupported backend "%s" try one of: %s' %
+                             (backend_name, ', '.join(registry.keys())))
 
 
 def _get_default_backend_name():
     if 'sqlite' in registry:
         return 'sqlite'
     return 'memory'
+

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -70,6 +70,15 @@ class CacheTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             CachedSession(CACHE_NAME, backend='nonexistent')
 
+    @mock.patch('requests_cache.backends.registry')
+    def test_missing_backend_dependency(self, mocked_registry):
+        # Testing that the correct error is thrown when a user does not have
+        # the Python package `redis` installed.  We mock out the registry
+        # to simulate `redis` not being installed.
+        mocked_registry.__getitem__.side_effect = KeyError
+        with self.assertRaises(ImportError):
+            CachedSession(CACHE_NAME, backend='redis')
+
     def test_hooks(self):
         state = defaultdict(int)
         for hook in ('response',):  # TODO it's only one hook here


### PR DESCRIPTION
Currently, if you don't have the Python package `redis` intalled
then you get the same message if you type:

    requests_cache.install_cache(backend='redis')

as if you type:

    requests_cache.install_cache(backend='nonsense!!!!')

