### PR TITLE
Fixing python3 import error in requests_cache.backends.dbdict

### DIFF
--- a/requests_cache/backends/storage/dbdict.py
+++ b/requests_cache/backends/storage/dbdict.py
@@ -6,13 +6,20 @@
 
     Dictionary-like objects for saving large data sets to `sqlite` database
 """
+from sys import version_info
 from collections import MutableMapping
 import sqlite3 as sqlite
 from contextlib import contextmanager
-try:
-    import threading
-except ImportError:
-    import dummy_threading as threading
+if version_info.major < 3:
+    try:
+        import threading
+    except ImportError:
+        import dummy_threading as threading
+else:
+    try:
+        import _thread as threading
+    except ImportError:
+        import _dummy_thread as threading
 try:
     import cPickle as pickle
 except ImportError:

--- a/requests_cache/backends/storage/dbdict.py
+++ b/requests_cache/backends/storage/dbdict.py
@@ -10,7 +10,7 @@ from sys import version_info
 from collections import MutableMapping
 import sqlite3 as sqlite
 from contextlib import contextmanager
-if version_info.major < 3:
+if version_info[0] < 3:
     try:
         import threading
     except ImportError:


### PR DESCRIPTION
This is a fix I created for the issue noted in #83