### PR TITLE
add gridfs support

### DIFF
--- a/requests_cache/backends/__init__.py
+++ b/requests_cache/backends/__init__.py
@@ -33,6 +33,13 @@ try:
 except ImportError:
     MongoCache = None
 
+
+try:
+    from .gridfs import GridFSCache
+    registry['gridfs'] = GridFSCache
+except ImportError:
+    GridFSCache = None
+
 try:
     from .redis import RedisCache
     registry['redis'] = RedisCache

--- a/requests_cache/backends/gridfs.py
+++ b/requests_cache/backends/gridfs.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+    requests_cache.backends.gridfs
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    ``gridfs`` cache backend
+    
+    Use MongoDB GridFS to support documents greater than 16MB.
+    
+    Usage:
+        requests_cache.install_cache(backend='gridfs')
+    
+    Or:
+        from pymongo import MongoClient
+        requests_cache.install_cache(backend='gridfs', connection=MongoClient('another-host.local'))
+"""
+from .base import BaseCache
+from .storage.mongodict import MongoDict
+from .storage.gridfspickledict import GridFSPickleDict
+
+
+class GridFSCache(BaseCache):
+    """ ``gridfs`` cache backend.
+    """
+    def __init__(self, db_name, **options):
+        """
+        :param db_name: database name
+        :param connection: (optional) ``pymongo.Connection``
+        """
+        super(GridFSCache, self).__init__(**options)
+        self.responses = GridFSPickleDict(db_name, options.get('connection'))
+        self.keys_map = MongoDict(db_name, 'http_redirects', self.responses.connection)
+

--- a/requests_cache/backends/storage/gridfspickledict.py
+++ b/requests_cache/backends/storage/gridfspickledict.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+    requests_cache.backends.mongodict
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Dictionary-like objects for saving large data sets to ``mongodb`` database
+"""
+
+from collections import MutableMapping
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
+
+# Use PyMongo 3 if present
+try:
+    from pymongo import MongoClient
+except ImportError:
+    from pymongo import Connection as MongoClient
+
+from gridfs import GridFS
+
+class GridFSPickleDict(MutableMapping):
+    """ MongoDict - a dictionary-like interface for ``mongo`` database
+    """
+    def __init__(self, db_name, connection=None):
+        """
+        :param db_name: database name (be careful with production databases)
+        :param connection: ``pymongo.Connection`` instance. If it's ``None``
+                           (default) new connection with default options will
+                           be created
+        """
+        if connection is not None:
+            self.connection = connection
+        else:
+            self.connection = MongoClient()
+
+        self.db = self.connection[db_name]
+        self.fs = GridFS(self.db)
+
+    def __getitem__(self, key):
+        result = self.fs.find_one({'_id': key})
+        if result is None:
+            raise KeyError
+        return pickle.loads(bytes(result.read()))
+
+    def __setitem__(self, key, item):
+        self.__delitem__(key)
+        self.fs.put(pickle.dumps(item), **{'_id': key})
+
+    def __delitem__(self, key):
+        res = self.fs.find_one({'_id': key})
+        if res is not None:
+            self.fs.delete(res._id)
+
+    def __len__(self):
+        return self.db['fs.files'].count()
+
+    def __iter__(self):
+        for d in self.fs.find():
+            yield d._id
+
+    def clear(self):
+        self.db['fs.files'].drop()
+        self.db['fs.chunks'].drop()
+
+    def __str__(self):
+        return str(dict(self.items()))
+

--- a/tests/test_gridfsdict.py
+++ b/tests/test_gridfsdict.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Path hack
+import os, sys
+sys.path.insert(0, os.path.abspath('..'))
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+from tests.test_custom_dict import BaseCustomDictTestCase
+try:
+    from requests_cache.backends.storage.mongodict import MongoDict
+    from requests_cache.backends.storage.gridfspickledict import GridFSPickleDict
+
+except ImportError:
+    print("pymongo not installed")
+else:
+    class MongoDictTestCase(BaseCustomDictTestCase, unittest.TestCase):
+        dict_class = MongoDict
+        pickled_dict_class = GridFSPickleDict
+
+    if __name__ == '__main__':
+        unittest.main()


### PR DESCRIPTION
Hey this support mongo gridfs, which allows file greater than 16MB.

Also, in this new cache store, I named `keys_map` as `http_redirects`  rather than `urls`, there was no document on it, the old name `urls` confused me for a while. I finally figured out what it does by checking the code.