### PR TITLE
add filesystem backend

### DIFF
--- a/requests_cache/backends/__init__.py
+++ b/requests_cache/backends/__init__.py
@@ -53,6 +53,13 @@ try:
 except ImportError:
     DynamoDbCache = None
 
+try:
+    from .filesystem import FilesystemCache
+    registry['filesystem'] = FilesystemCache
+except ImportError:
+    FilesystemCache = None
+
+
 def create_backend(backend_name, cache_name, options):
     if isinstance(backend_name, BaseCache):
         return backend_name

--- a/requests_cache/backends/filesystem.py
+++ b/requests_cache/backends/filesystem.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+    requests_cache.backends.filesystem
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    ``filesystem`` cache backend
+"""
+from .base import BaseCache
+from .storage.filesystemdict import FilesystemDict
+
+
+class FilesystemCache(BaseCache):
+    """ ``filesystem`` cache backend.
+    """
+    def __init__(self, name, **options):
+        super(FilesystemCache, self).__init__(**options)
+
+        fs_class = FilesystemDict(
+            options.get('cache_dir', '/tmp/{0}'.format(name)),
+            options.get('mode', 0600),
+            options.get('threshold', 500))
+
+        self.responses = fs_class
+        self.keys_map = fs_class

--- a/requests_cache/backends/storage/filesystemdict.py
+++ b/requests_cache/backends/storage/filesystemdict.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+    requests_cache.backends.filesystemdict
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Dictionary-like objects for saving large data sets to ``filesystem``
+"""
+import os
+import errno
+import datetime
+
+from collections import MutableMapping
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
+
+
+class FilesystemDict(MutableMapping):
+    """A cache that stores the items on the file system.  This cache depends
+    on being the only user of the `cache_dir`.
+    :param cache_dir: the directory where cache files are stored.
+    :param mode: the file mode wanted for the cache files, default 0600
+    :param threshold: the maximum number of items the cache stores before
+                      it starts deleting some.
+    """
+
+    def __init__(self, cache_dir, mode, threshold):
+        self.cache_dir = cache_dir
+        self.mode = mode
+        self.threshold = threshold
+
+        try:
+            os.makedirs(self.cache_dir)
+        except OSError as err:
+            if err.errno != errno.EEXIST:
+                raise
+
+
+    def __getitem__(self, key):
+        file_path = "{0}/{1}".format(self.cache_dir, key)
+        try:
+            return pickle.load(open(file_path, 'rb'))
+        except (IOError, OSError, pickle.PickleError):
+            raise KeyError
+
+
+    def __setitem__(self, key, item):
+        self._prune()
+        file_path = "{0}/{1}".format(self.cache_dir, key)
+        with open(file_path, 'wb') as file:
+            pickle.dump(item, file, pickle.HIGHEST_PROTOCOL)
+        os.chmod(file_path, self.mode)
+
+
+    def __delitem__(self, key):
+        try:
+            file_path = "{0}/{1}".format(self.cache_dir, key)
+            os.remove(file_path)
+        except (IOError, OSError):
+            raise KeyError
+
+
+    def __len__(self):
+        return len(self._list_dir())
+
+
+    def __iter__(self):
+        for file_path in self._list_dir:
+            yield file_path
+
+
+    def clear(self):
+        for file in self._list_dir():
+            os.remove(file)
+
+
+    def _list_dir(self):
+        """return a list of (fully qualified) cache filenames"""
+        return [os.path.join(self.cache_dir, fn)
+                for fn in os.listdir(self.cache_dir)]
+
+
+    def _prune(self):
+        entries = self._list_dir()
+        if len(entries) > self.threshold:
+            now = datetime.datetime.now()
+            for idx, fname in enumerate(entries):
+                print idx, fname
+                try:
+                    remove = False
+                    with open(fname, 'rb') as f:
+                        #(<requests_cache.backends.base._Store>, <datetime>))
+                        _, expires = pickle.load(f)
+                    remove = (expires != 0 and expires <= now) or idx % 3 == 0
+
+                    if remove:
+                        os.remove(fname)
+                except (IOError, OSError):
+                    pass

--- a/tests/test_filesystemdict.py
+++ b/tests/test_filesystemdict.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Path hack
+import os, sys
+sys.path.insert(0, os.path.abspath('..'))
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+from tests.test_custom_dict import BaseCustomDictTestCase
+from requests_cache.backends.storage.filesystemdict import FilesystemDict
+
+class FilesystemDictTestCase(BaseCustomDictTestCase, unittest.TestCase):
+    dict_class = FilesystemDict
+    pickled_dict_class = FilesystemDict
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add filesystem backend, useful for local dev.
Largely copied on [werkzeug](https://github.com/pallets/werkzeug/blob/master/werkzeug/contrib/cache.py#L681)