### PR TITLE
Add response filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.pyo
 *.idea
 *.sqlite
+*.egg-info
 build
 _build
 dist

--- a/requests_cache/core.py
+++ b/requests_cache/core.py
@@ -136,7 +136,10 @@ class CachedSession(OriginalSession):
 
         main_key = self.cache.create_key(response.request)
 
-        if not response.from_cache and self._filter_fn(response) is not True:
+        # If self._return_old_data_on_error is set,
+        # responses won't always have the from_cache attribute.
+        if (hasattr(response, "from_cache") and not response.from_cache
+            and self._filter_fn(response) is not True):
             self.cache.delete(main_key)
             return response
 


### PR DESCRIPTION
Say for example you have an API that sets some `error` field in its JSON response, you might want to avoid caching responses which return 200 but have a non-null error field. So you could do something like:

```python
sess = CachedSession(filter_fn=lambda r: r.json().get("error") is None)
```

I toyed with putting this in `send` before caching to make it a generic post-processing function (#98), but I thought that might be confusing to have both functionalities. I could probably make another PR with that feature via a separate mechanimsm if there's interest. 

I'll add some tests when I get a chance, just wanted to get this idea out there.