### PR TITLE
Allow headers to be used as cache key for requests with body

### DIFF
--- a/requests_cache/backends/base.py
+++ b/requests_cache/backends/base.py
@@ -31,7 +31,7 @@ class BaseCache(object):
         self.keys_map = {}
         #: `key_in_cache` -> `response` mapping
         self.responses = {}
-        self._include_get_headers = kwargs.get("include_get_headers", False)
+        self._include_headers = kwargs.get("include_headers", False)
         self._ignored_parameters = set(kwargs.get("ignored_parameters") or [])
 
     def save_response(self, key, response):
@@ -225,8 +225,7 @@ class BaseCache(object):
         key.update(_to_bytes(url))
         if request.body:
             key.update(_to_bytes(body))
-        else:
-            if self._include_get_headers and request.headers != _DEFAULT_HEADERS:
+        if self._include_headers and request.headers != _DEFAULT_HEADERS:
                 for name, value in sorted(request.headers.items()):
                     key.update(_to_bytes(name))
                     key.update(_to_bytes(value))

--- a/requests_cache/backends/base.py
+++ b/requests_cache/backends/base.py
@@ -226,9 +226,9 @@ class BaseCache(object):
         if request.body:
             key.update(_to_bytes(body))
         if self._include_headers and request.headers != _DEFAULT_HEADERS:
-                for name, value in sorted(request.headers.items()):
-                    key.update(_to_bytes(name))
-                    key.update(_to_bytes(value))
+            for name, value in sorted(request.headers.items()):
+                key.update(_to_bytes(name))
+                key.update(_to_bytes(value))
         return key.hexdigest()
 
     def __str__(self):

--- a/requests_cache/core.py
+++ b/requests_cache/core.py
@@ -57,7 +57,7 @@ class CachedSession(OriginalSession):
         :kwarg backend_options: options for chosen backend. See corresponding
                                 :ref:`sqlite <backends_sqlite>`, :ref:`mongo <backends_mongo>` 
                                 and :ref:`redis <backends_redis>` backends API documentation
-        :param include_get_headers: If `True` headers will be part of cache key.
+        :param include_headers: If `True` headers will be part of cache key.
                                     E.g. after get('some_link', headers={'Accept':'application/json'})
                                     get('some_link', headers={'Accept':'application/xml'}) is not from cache.
         :param ignored_parameters: List of parameters to be excluded from the cache key.

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -306,7 +306,7 @@ class CacheTestCase(unittest.TestCase):
 
     def test_headers_in_get_query(self):
         url = httpbin("get")
-        s = CachedSession(CACHE_NAME, CACHE_BACKEND, include_get_headers=True)
+        s = CachedSession(CACHE_NAME, CACHE_BACKEND, include_headers=True)
         headers = {"Accept": "text/json"}
         self.assertFalse(s.get(url, headers=headers).from_cache)
         self.assertTrue(s.get(url, headers=headers).from_cache)


### PR DESCRIPTION
Updating the name of the variable and logic to allow for headers to be used as keys for requests that contain a body.