### PR TITLE
Fix travis build for python2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ services:
 install:
   - pip install --upgrade .
   - pip install --upgrade -r requirements-test.txt
-  - pip install coveralls
+  - pip install coveralls==1.1
 
 script: py.test -s -v tests --cov requests_cache
 


### PR DESCRIPTION
The last version of coveralls that I could still install on python2.6 was with `pip install coveralls==1.1`. 

I had sum difficulty even creating the env, as it appears even setuptools and pip have dropped support for python2.6. I think it's reasonable at this point to drop 2.6.
