### PR TITLE
Fix DeprecationWarning from collections

### DIFF
--- a/requests_cache/backends/storage/mongodict.py
+++ b/requests_cache/backends/storage/mongodict.py
@@ -7,7 +7,11 @@
     Dictionary-like objects for saving large data sets to ``mongodb`` database
 """
 
-from collections import MutableMapping
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import MutableMapping
+
 try:
     import cPickle as pickle
 except ImportError:


### PR DESCRIPTION
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working.

fixes #126