### PR TITLE
Remove Python 2.6 Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 sudo: false
 python:
-  - "2.6"
   - "2.7"
   - "3.4"
   - "3.5"

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup(
         'Intended Audience :: Developers',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
     ],


### PR DESCRIPTION
Python 2.6 is no longer maintained by the Python core team, no longer supported by `pymongo`, and is breaking Travis CI builds