### PR TITLE
vacuum the sqlite database after clearing a table

### DIFF
--- a/requests_cache/backends/storage/dbdict.py
+++ b/requests_cache/backends/storage/dbdict.py
@@ -152,6 +152,7 @@ class DbDict(MutableMapping):
             con.execute("drop table `%s`" % self.table_name)
             con.execute("create table `%s` (key PRIMARY KEY, value)" %
                         self.table_name)
+            con.execute("vacuum")
 
     def __str__(self):
         return str(dict(self.items()))


### PR DESCRIPTION
this is required so that the sqlite file size actually decreases after clear (which is probably expected by users).

Cheers,

Olivier