### PR TITLE
Refactor CachedSession to be usable as a mixin class

### DIFF
--- a/requests_cache/__init__.py
+++ b/requests_cache/__init__.py
@@ -28,11 +28,13 @@ __version__ = '0.6.0'
 try:
     from .core import (
         CachedSession,
+        CacheMixin,
         clear,
         disabled,
         enabled,
         get_cache,
         install_cache,
+        is_installed,
         remove_expired_responses,
         uninstall_cache,
     )

--- a/requests_cache/backends/__init__.py
+++ b/requests_cache/backends/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+# noqa: F401
 """
     requests_cache.backends
     ~~~~~~~~~~~~~~~~~~~~~~~

--- a/requests_cache/backends/__init__.py
+++ b/requests_cache/backends/__init__.py
@@ -7,7 +7,7 @@
 """
 
 
-from .base import BaseCache
+from .base import BACKEND_KWARGS, BaseCache
 
 registry = {
     'memory': BaseCache,

--- a/requests_cache/backends/base.py
+++ b/requests_cache/backends/base.py
@@ -14,7 +14,23 @@ from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 import requests
 
-_DEFAULT_HEADERS = requests.utils.default_headers()
+# All backend-specific keyword arguments combined
+BACKEND_KWARGS = [
+    'connection',
+    'db_name',
+    'endpont_url',
+    'extension',
+    'fast_save',
+    'ignored_parameters',
+    'include_get_headers',
+    'location',
+    'name',
+    'namespace',
+    'read_capacity_units',
+    'region_name',
+    'write_capacity_units',
+]
+DEFAULT_HEADERS = requests.utils.default_headers()
 
 
 class BaseCache(object):
@@ -230,7 +246,7 @@ class BaseCache(object):
         if request.body:
             key.update(_to_bytes(body))
         else:
-            if self._include_get_headers and request.headers != _DEFAULT_HEADERS:
+            if self._include_get_headers and request.headers != DEFAULT_HEADERS:
                 for name, value in sorted(request.headers.items()):
                     key.update(_to_bytes(name))
                     key.update(_to_bytes(value))

--- a/requests_cache/backends/dynamodb.py
+++ b/requests_cache/backends/dynamodb.py
@@ -17,7 +17,7 @@ class DynamoDbCache(BaseCache):
         :param namespace: dynamodb table name (default: ``'requests-cache'``)
         :param connection: (optional) ``boto3.resource('dynamodb')``
         """
-        super(DynamoDbCache, self).__init__(**options)
+        super().__init__(**options)
         self.responses = DynamoDbDict(
             table_name,
             'responses',

--- a/requests_cache/backends/gridfs.py
+++ b/requests_cache/backends/gridfs.py
@@ -27,6 +27,6 @@ class GridFSCache(BaseCache):
         :param db_name: database name
         :param connection: (optional) ``pymongo.Connection``
         """
-        super(GridFSCache, self).__init__(**options)
+        super().__init__(**options)
         self.responses = GridFSPickleDict(db_name, options.get('connection'))
         self.keys_map = MongoDict(db_name, 'http_redirects', self.responses.connection)

--- a/requests_cache/backends/gridfs.py
+++ b/requests_cache/backends/gridfs.py
@@ -4,12 +4,12 @@
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     ``gridfs`` cache backend
-    
+
     Use MongoDB GridFS to support documents greater than 16MB.
-    
+
     Usage:
         requests_cache.install_cache(backend='gridfs')
-    
+
     Or:
         from pymongo import MongoClient
         requests_cache.install_cache(backend='gridfs', connection=MongoClient('another-host.local'))

--- a/requests_cache/backends/mongo.py
+++ b/requests_cache/backends/mongo.py
@@ -17,6 +17,6 @@ class MongoCache(BaseCache):
         :param db_name: database name (default: ``'requests-cache'``)
         :param connection: (optional) ``pymongo.Connection``
         """
-        super(MongoCache, self).__init__(**options)
+        super().__init__(**options)
         self.responses = MongoPickleDict(db_name, 'responses', options.get('connection'))
         self.keys_map = MongoDict(db_name, 'urls', self.responses.connection)

--- a/requests_cache/backends/redis.py
+++ b/requests_cache/backends/redis.py
@@ -17,6 +17,6 @@ class RedisCache(BaseCache):
         :param namespace: redis namespace (default: ``'requests-cache'``)
         :param connection: (optional) ``redis.StrictRedis``
         """
-        super(RedisCache, self).__init__(**options)
+        super().__init__(**options)
         self.responses = RedisDict(namespace, 'responses', options.get('connection'))
         self.keys_map = RedisDict(namespace, 'urls', self.responses.connection)

--- a/requests_cache/backends/sqlite.py
+++ b/requests_cache/backends/sqlite.py
@@ -23,6 +23,6 @@ class DbCache(BaseCache):
                           See :ref:`backends.DbDict <backends_dbdict>` for more info
         :param extension: extension for filename (default: ``'.sqlite'``)
         """
-        super(DbCache, self).__init__(**options)
+        super().__init__(**options)
         self.responses = DbPickleDict(str(location) + extension, 'responses', fast_save=fast_save)
         self.keys_map = DbDict(location + extension, 'urls')

--- a/requests_cache/backends/storage/dbdict.py
+++ b/requests_cache/backends/storage/dbdict.py
@@ -144,7 +144,7 @@ class DbPickleDict(DbDict):
     """Same as :class:`DbDict`, but pickles values before saving"""
 
     def __setitem__(self, key, item):
-        super(DbPickleDict, self).__setitem__(key, sqlite3.Binary(pickle.dumps(item)))
+        super().__setitem__(key, sqlite3.Binary(pickle.dumps(item)))
 
     def __getitem__(self, key):
-        return pickle.loads(bytes(super(DbPickleDict, self).__getitem__(key)))
+        return pickle.loads(bytes(super().__getitem__(key)))

--- a/requests_cache/backends/storage/mongodict.py
+++ b/requests_cache/backends/storage/mongodict.py
@@ -67,7 +67,7 @@ class MongoPickleDict(MongoDict):
     """Same as :class:`MongoDict`, but pickles values before saving"""
 
     def __setitem__(self, key, item):
-        super(MongoPickleDict, self).__setitem__(key, pickle.dumps(item))
+        super().__setitem__(key, pickle.dumps(item))
 
     def __getitem__(self, key):
-        return pickle.loads(bytes(super(MongoPickleDict, self).__getitem__(key)))
+        return pickle.loads(bytes(super().__getitem__(key)))

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ extras_require = {
         'isort',
         'pre-commit',
         'pytest>=5.0',
-        'pytest-cov',
+        'pytest-cov>=2.11',
     ],
 }
 # All development/testing packages combined

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,0 @@
-#!/usr/bin/env python


### PR DESCRIPTION
Closes:
* #158 
* #163
* #149 
* #146
* #144  
* #87

Related changes:
* Add sanity checks to get_cache, clear, and remove_expired_responses to make sure requests-cache is installed before calling CachedSession methods

## Example with requests-html (#149)
```python
import requests
from requests_cache import CacheMixin, install_cache
from requests_html import HTMLSession

class CachedHTMLSession(CacheMixin, HTMLSession):
    """Session with features from both CachedSession and HTMLSession"""

session = CachedHTMLSession()
r = session.get("https://github.com/")
print(r.from_cache, r.html.links)
```

Or, using the monkey-patch method:
```python
install_cache(session_factory=CachedHTMLSession)
r = requests.get("https://github.com/")
print(r.from_cache, r.html.links)
```
Note that this usage would be more ideal if requests-html could also be used as a mixin.

## Example with internetarchive (#158)
Pretty much the same as above:
```python
import requests
from requests_cache import CacheMixin, install_cache
from internetarchive.session import ArchiveSession

class CachedArchiveSession(CacheMixin, ArchiveSession):
    """Session with features from both CachedSession and ArchiveSession"""
```

## Example with requests-mock (#87)
```python
import requests
from requests_mock import Mocker
from requests_cache import CachedSession

session = CachedSession()
with Mocker(session=session) as m:
    m.get('http://test.com', text='mock_response')
    response = session.get('http://test.com')
    print(response.text)
```

Examples have also been added to the docs.