### PR TITLE
fix for prepared requests

### DIFF
--- a/requests_cache/core.py
+++ b/requests_cache/core.py
@@ -159,6 +159,12 @@ class CacheMixin:
         response = dispatch_hook('response', request.hooks, response, **kwargs)
         return response
 
+    def prepare_request(self, request):
+        prepped = super().prepare_request(request)
+        self._request_expire_after='default'
+        return prepped
+
+
     def request(self, method, url, params=None, data=None, expire_after='default', **kwargs):
         """This method prepares and sends a request while automatically
         performing any necessary caching operations.


### PR DESCRIPTION
Prepared requests fail used from some libraries with the following common code:
```
        req = requests.Request(verb, url, json=json, data=data, params=params, **opts)
        prepped = self.session.prepare_request(req)

       ... 

        result = self.session.send(prepped, timeout=timeout, **settings)
```

This patch simply sets the default request_expire _after in the session, though it might be better to set the request_expire_after in the request itself before the send (since it may be re-used).
