### PR TITLE
Add property to get all URLs in the cache

### DIFF
--- a/requests_cache/backends/base.py
+++ b/requests_cache/backends/base.py
@@ -8,6 +8,7 @@
 import hashlib
 import json
 from pickle import PickleError
+from typing import List
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 import requests
@@ -31,6 +32,13 @@ class BaseCache(object):
         self.responses = {}
         self._include_get_headers = kwargs.get("include_get_headers", False)
         self._ignored_parameters = set(kwargs.get("ignored_parameters") or [])
+
+    @property
+    def urls(self) -> List[str]:
+        """Get all URLs currently in the cache"""
+        response_urls = [response.url for response in self.responses.values()]
+        redirect_urls = list(self.keys_map.keys())
+        return sorted(response_urls + redirect_urls)
 
     def save_response(self, key: str, response: AnyResponse, expire_after: ExpirationTime = None):
         """Save response to cache

--- a/requests_cache/backends/base.py
+++ b/requests_cache/backends/base.py
@@ -22,13 +22,11 @@ class BaseCache(object):
     """Base class for cache implementations, which can also be used as in-memory cache.
 
     To extend it you can provide dictionary-like objects for
-    :attr:`keys_map` and :attr:`responses` or override public methods.
+    :attr:`redirects` and :attr:`responses` or override public methods.
     """
 
     def __init__(self, *args, **kwargs):
-        #: `key` -> `key_in_responses` mapping
-        self.keys_map = {}
-        #: `key_in_cache` -> `response` mapping
+        self.redirects = {}
         self.responses = {}
         self._include_get_headers = kwargs.get("include_get_headers", False)
         self._ignored_parameters = set(kwargs.get("ignored_parameters") or [])
@@ -37,7 +35,7 @@ class BaseCache(object):
     def urls(self) -> List[str]:
         """Get all URLs currently in the cache"""
         response_urls = [response.url for response in self.responses.values()]
-        redirect_urls = list(self.keys_map.keys())
+        redirect_urls = list(self.redirects.keys())
         return sorted(response_urls + redirect_urls)
 
     def save_response(self, key: str, response: AnyResponse, expire_after: ExpirationTime = None):
@@ -59,7 +57,7 @@ class BaseCache(object):
             new_key: New resource key (e.g. url from redirect)
             key_to_response: Key which can be found in :attr:`responses`
         """
-        self.keys_map[new_key] = key_to_response
+        self.redirects[new_key] = key_to_response
 
     def get_response(self, key: str, default=None) -> CachedResponse:
         """Retrieves response for `key` if it's stored in cache, otherwise returns `default`
@@ -70,7 +68,7 @@ class BaseCache(object):
         """
         try:
             if key not in self.responses:
-                key = self.keys_map[key]
+                key = self.redirects[key]
             response = self.responses[key]
             response.reset()  # In case response was in memory and raw content has already been read
             return response
@@ -84,10 +82,10 @@ class BaseCache(object):
                 response = self.responses[key]
                 del self.responses[key]
             else:
-                response = self.responses[self.keys_map[key]]
-                del self.keys_map[key]
+                response = self.responses[self.redirects[key]]
+                del self.redirects[key]
             for r in response.history:
-                del self.keys_map[self.create_key(r.request)]
+                del self.redirects[self.create_key(r.request)]
         except KeyError:
             pass
 
@@ -100,7 +98,7 @@ class BaseCache(object):
     def clear(self):
         """Delete all items from the cache"""
         self.responses.clear()
-        self.keys_map.clear()
+        self.redirects.clear()
 
     def remove_expired_responses(self, expire_after: ExpirationTime = None):
         """Remove expired responses from the cache, optionally with revalidation
@@ -117,7 +115,7 @@ class BaseCache(object):
 
     def has_key(self, key: str) -> bool:
         """Returns `True` if cache has `key`, `False` otherwise"""
-        return key in self.responses or key in self.keys_map
+        return key in self.responses or key in self.redirects
 
     def has_url(self, url: str) -> bool:
         """Returns `True` if cache has `url`, `False` otherwise. Works only for GET request urls"""
@@ -175,7 +173,7 @@ class BaseCache(object):
         return [(k, v) for k, v in data if k not in self._ignored_parameters]
 
     def __str__(self):
-        return f'redirects: {len(self.keys_map)}\nresponses: {len(self.responses)}'
+        return f'redirects: {len(self.redirects)}\nresponses: {len(self.responses)}'
 
 
 def _encode(value, encoding='utf-8') -> bytes:

--- a/requests_cache/backends/dynamodb.py
+++ b/requests_cache/backends/dynamodb.py
@@ -27,4 +27,4 @@ class DynamoDbCache(BaseCache):
             options.get('read_capacity_units'),
             options.get('write_capacity_units'),
         )
-        self.keys_map = DynamoDbDict(table_name, 'urls', self.responses.connection)
+        self.redirects = DynamoDbDict(table_name, 'redirects', self.responses.connection)

--- a/requests_cache/backends/gridfs.py
+++ b/requests_cache/backends/gridfs.py
@@ -29,4 +29,4 @@ class GridFSCache(BaseCache):
         """
         super().__init__(**options)
         self.responses = GridFSPickleDict(db_name, options.get('connection'))
-        self.keys_map = MongoDict(db_name, 'http_redirects', self.responses.connection)
+        self.redirects = MongoDict(db_name, 'redirects', self.responses.connection)

--- a/requests_cache/backends/mongo.py
+++ b/requests_cache/backends/mongo.py
@@ -19,4 +19,4 @@ class MongoCache(BaseCache):
         """
         super().__init__(**options)
         self.responses = MongoPickleDict(db_name, 'responses', options.get('connection'))
-        self.keys_map = MongoDict(db_name, 'urls', self.responses.connection)
+        self.redirects = MongoDict(db_name, 'redirects', self.responses.connection)

--- a/requests_cache/backends/redis.py
+++ b/requests_cache/backends/redis.py
@@ -19,4 +19,4 @@ class RedisCache(BaseCache):
         """
         super().__init__(**options)
         self.responses = RedisDict(namespace, 'responses', options.get('connection'))
-        self.keys_map = RedisDict(namespace, 'urls', self.responses.connection)
+        self.redirects = RedisDict(namespace, 'redirects', self.responses.connection)

--- a/requests_cache/backends/sqlite.py
+++ b/requests_cache/backends/sqlite.py
@@ -25,4 +25,4 @@ class DbCache(BaseCache):
         """
         super().__init__(**options)
         self.responses = DbPickleDict(str(location) + extension, 'responses', fast_save=fast_save)
-        self.keys_map = DbDict(location + extension, 'urls')
+        self.redirects = DbDict(location + extension, 'redirects')

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -130,6 +130,15 @@ def test_repr():
     assert 'redirects: 2' in str(session.cache) and 'responses: 1' in str(session.cache)
 
 
+def test_urls(mock_session):
+    for url in [MOCKED_URL, MOCKED_URL_JSON, MOCKED_URL_HTTPS]:
+        mock_session.get(url)
+    mock_session.cache.keys_map[MOCKED_URL_REDIRECT] = MOCKED_URL
+
+    expected_urls = [MOCKED_URL, MOCKED_URL_JSON, MOCKED_URL_HTTPS, MOCKED_URL_REDIRECT]
+    assert set(mock_session.cache.urls) == set(expected_urls)
+
+
 # TODO: More event types; make a mock response that emulates hook behavior
 def test_hooks(mock_session):
     state = defaultdict(int)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -123,8 +123,8 @@ def test_repr():
     cache_name = 'requests_cache_test'
     session = CachedSession(cache_name=cache_name, backend='memory', expire_after=10)
     session.cache.responses['key'] = 'value'
-    session.cache.keys_map['key'] = 'value'
-    session.cache.keys_map['key_2'] = 'value'
+    session.cache.redirects['key'] = 'value'
+    session.cache.redirects['key_2'] = 'value'
 
     assert cache_name in repr(session) and '10' in repr(session)
     assert 'redirects: 2' in str(session.cache) and 'responses: 1' in str(session.cache)
@@ -133,7 +133,7 @@ def test_repr():
 def test_urls(mock_session):
     for url in [MOCKED_URL, MOCKED_URL_JSON, MOCKED_URL_HTTPS]:
         mock_session.get(url)
-    mock_session.cache.keys_map[MOCKED_URL_REDIRECT] = MOCKED_URL
+    mock_session.cache.redirects[MOCKED_URL_REDIRECT] = MOCKED_URL
 
     expected_urls = [MOCKED_URL, MOCKED_URL_JSON, MOCKED_URL_HTTPS, MOCKED_URL_REDIRECT]
     assert set(mock_session.cache.urls) == set(expected_urls)
@@ -204,7 +204,7 @@ def test_delete_redirect(mock_session):
     response_key = mock_session.cache._url_to_key(MOCKED_URL)
     redirect_key = mock_session.cache._url_to_key(MOCKED_URL_REDIRECT)
     mock_session.get(MOCKED_URL)
-    mock_session.cache.keys_map[redirect_key] = response_key
+    mock_session.cache.redirects[redirect_key] = response_key
 
     mock_session.cache.delete_url(MOCKED_URL_REDIRECT)
     assert mock_session.cache.has_url(MOCKED_URL)


### PR DESCRIPTION
This also renames the `BaseCache.keys_map` property and its associated table to `redirects` to make it more clear what it does. This seemed to be a point of confusion on several issues. Also adding info about this to the docs in #191.