### PR TITLE
Improve request normalization for generating cache keys

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,6 +14,7 @@
 * Add `BaseCache.urls` property to get all URLs persisted in the cache
 * Add `timeout` parameter to SQLite backend
 * Add optional support for `itsdangerous` for more secure serialization
+* Handle additional edge cases with request normalization for cache keys (to avoid duplicate cached responses)
 * Update usage of deprecated MongoClient `save()` method
 * Fix TypeError with `DbPickleDict` initialization
 * Fix usage of `CachedSession.cache_disabled` if used within another contextmanager

--- a/requests_cache/backends/__init__.py
+++ b/requests_cache/backends/__init__.py
@@ -1,6 +1,6 @@
 """Classes and functions for cache persistence"""
 # flake8: noqa: F401
-from .base import BaseCache
+from .base import BaseCache, normalize_dict
 
 # All backend-specific keyword arguments combined
 BACKEND_KWARGS = [

--- a/requests_cache/backends/__init__.py
+++ b/requests_cache/backends/__init__.py
@@ -1,6 +1,7 @@
 """Classes and functions for cache persistence"""
 # flake8: noqa: F401
-from .base import BaseCache, normalize_dict
+from ..cache_keys import normalize_dict
+from .base import BaseCache
 
 # All backend-specific keyword arguments combined
 BACKEND_KWARGS = [

--- a/requests_cache/backends/base.py
+++ b/requests_cache/backends/base.py
@@ -1,20 +1,15 @@
-import hashlib
-import json
 import pickle
 import warnings
 from abc import ABC
 from collections.abc import MutableMapping
 from logging import getLogger
-from operator import itemgetter
-from typing import Dict, Iterable, List, Mapping, Union
-from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+from typing import Iterable, List, Union
 
 import requests
-from url_normalize import url_normalize
 
+from ..cache_keys import create_key, url_to_key
 from ..response import AnyResponse, CachedResponse, ExpirationTime
 
-DEFAULT_HEADERS = requests.utils.default_headers()
 logger = getLogger(__name__)
 
 
@@ -93,7 +88,7 @@ class BaseCache:
         try:
             response = self.responses[key] or self.responses[self.redirects[key]]
             for r in response.history:
-                del self.redirects[self.create_key(r.request)]
+                del self.redirects[create_key(r.request, self._ignored_parameters)]
         except Exception:
             pass
 
@@ -101,7 +96,7 @@ class BaseCache:
         """Delete response + redirects associated with `url` from cache.
         Works only for GET requests.
         """
-        self.delete(self._url_to_key(url))
+        self.delete(url_to_key(url, self._ignored_parameters))
 
     def clear(self):
         """Delete all items from the cache"""
@@ -131,64 +126,17 @@ class BaseCache:
             if response.is_expired:
                 self.delete(key)
 
+    def create_key(self, request: requests.PreparedRequest) -> str:
+        """Create a normalized cache key from a request object"""
+        return create_key(request, self._ignored_parameters, self._include_get_headers)
+
     def has_key(self, key: str) -> bool:
         """Returns `True` if cache has `key`, `False` otherwise"""
         return key in self.responses or key in self.redirects
 
     def has_url(self, url: str) -> bool:
         """Returns `True` if cache has `url`, `False` otherwise. Works only for GET request urls"""
-        return self.has_key(self._url_to_key(url))  # noqa: W601
-
-    def _url_to_key(self, url: str) -> str:
-        session = requests.Session()
-        return self.create_key(session.prepare_request(requests.Request('GET', url)))
-
-    def create_key(self, request: requests.PreparedRequest) -> str:
-        url = self._remove_ignored_url_parameters(request)
-        url = url_normalize(url)
-        body = self._remove_ignored_body_parameters(request)
-        key = hashlib.sha256()
-        key.update(_encode(request.method.upper()))
-        key.update(_encode(url))
-
-        if body:
-            key.update(_encode(body))
-        else:
-            if self._include_get_headers and request.headers != DEFAULT_HEADERS:
-                for name, value in normalize_dict(request.headers).items():
-                    key.update(_encode(f'{name}={value}'))
-        return key.hexdigest()
-
-    def _remove_ignored_url_parameters(self, request: requests.PreparedRequest) -> str:
-        url = str(request.url)
-        if not self._ignored_parameters:
-            return url
-
-        url = urlparse(url)
-        query = parse_qsl(url.query)
-        query = self._filter_ignored_parameters(query)
-        query = urlencode(query)
-        url = urlunparse((url.scheme, url.netloc, url.path, url.params, query, url.fragment))
-        return url
-
-    def _remove_ignored_body_parameters(self, request: requests.PreparedRequest) -> str:
-        body = request.body
-        content_type = request.headers.get('content-type')
-        if not self._ignored_parameters or not body or not content_type:
-            return request.body
-
-        if content_type == 'application/x-www-form-urlencoded':
-            body = parse_qsl(body)
-            body = self._filter_ignored_parameters(body)
-            body = urlencode(body)
-        elif content_type == 'application/json':
-            body = json.loads(_decode(body))
-            body = self._filter_ignored_parameters(sorted(body.items()))
-            body = json.dumps(body)
-        return body
-
-    def _filter_ignored_parameters(self, data):
-        return [(k, v) for k, v in data if k not in self._ignored_parameters]
+        return self.has_key(url_to_key(url, self._ignored_parameters))  # noqa: W601
 
     def __str__(self):
         return f'redirects: {len(self.redirects)}\nresponses: {len(self.responses)}'
@@ -241,40 +189,3 @@ class BaseStorage(MutableMapping, ABC):
             return Serializer(secret_key, salt=salt, serializer=pickle)
         else:
             return pickle
-
-
-def normalize_dict(items: Union[Mapping, str, bytes] = None, normalize_data: bool = False) -> Union[Dict, str, bytes]:
-    """Sort items in a dict
-
-    Args:
-        items: Request params, data, or json
-        normalize_data: Also normalize stringified JSON
-    """
-
-    def sort_dict(d):
-        return dict(sorted(d.items(), key=itemgetter(0)))
-
-    if isinstance(items, Mapping):
-        return sort_dict(items)
-    if normalize_data and isinstance(items, (bytes, str)):
-        # Attempt to load body as JSON; not doing this by default as it could impact performance
-        try:
-            dict_items = json.loads(_decode(items))
-            dict_items = json.dumps(sort_dict(dict_items))
-            return dict_items.encode('utf-8') if isinstance(items, bytes) else dict_items
-        except Exception:
-            pass
-
-    return items
-
-
-def _encode(value, encoding='utf-8') -> bytes:
-    """Encode a value, if it hasn't already been"""
-    return value if isinstance(value, bytes) else value.encode(encoding)
-
-
-def _decode(value, encoding='utf-8') -> str:
-    """Decode a value, if hasn't already been.
-    Note: PreparedRequest.body is always encoded in utf-8.
-    """
-    return value if isinstance(value, str) else value.decode(encoding)

--- a/requests_cache/cache_keys.py
+++ b/requests_cache/cache_keys.py
@@ -1,0 +1,109 @@
+import hashlib
+import json
+from operator import itemgetter
+from typing import Iterable, List, Mapping, Tuple, Union
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+
+import requests
+from url_normalize import url_normalize
+
+DEFAULT_HEADERS = requests.utils.default_headers()
+RequestContent = Union[Mapping, str, bytes]
+
+
+def create_key(
+    request: requests.PreparedRequest,
+    ignored_params: Iterable[str] = None,
+    include_get_headers: bool = False,
+) -> str:
+    """Create a normalized cache key from a request object"""
+    url = remove_ignored_url_params(request, ignored_params)
+    url = url_normalize(url)
+    body = remove_ignored_body_params(request, ignored_params)
+    key = hashlib.sha256()
+    key.update(_encode(request.method.upper()))
+    key.update(_encode(url))
+
+    if body:
+        key.update(_encode(body))
+    else:
+        if include_get_headers and request.headers != DEFAULT_HEADERS:
+            for name, value in normalize_dict(request.headers).items():
+                key.update(_encode(f'{name}={value}'))
+    return key.hexdigest()
+
+
+def remove_ignored_url_params(request: requests.PreparedRequest, ignored_params: Iterable[str]) -> str:
+    url = str(request.url)
+    if not ignored_params:
+        return url
+
+    url = urlparse(url)
+    query = parse_qsl(url.query)
+    query = filter_params(query, ignored_params)
+    query = urlencode(query)
+    url = urlunparse((url.scheme, url.netloc, url.path, url.params, query, url.fragment))
+    return url
+
+
+def remove_ignored_body_params(request: requests.PreparedRequest, ignored_params: Iterable[str]) -> str:
+    body = request.body
+    content_type = request.headers.get('content-type')
+    if not ignored_params or not body or not content_type:
+        return request.body
+
+    if content_type == 'application/x-www-form-urlencoded':
+        body = parse_qsl(body)
+        body = filter_params(body, ignored_params)
+        body = urlencode(body)
+    elif content_type == 'application/json':
+        body = json.loads(_decode(body))
+        body = filter_params(sorted(body.items()), ignored_params)
+        body = json.dumps(body)
+    return body
+
+
+def filter_params(data: List[Tuple], ignored_params: Iterable[str]) -> List[Tuple]:
+    return [(k, v) for k, v in data if k not in ignored_params]
+
+
+def normalize_dict(items: RequestContent = None, normalize_data: bool = True) -> RequestContent:
+    """Sort items in a dict
+
+    Args:
+        items: Request params, data, or json
+        normalize_data: Also normalize stringified JSON
+    """
+
+    def sort_dict(d):
+        return dict(sorted(d.items(), key=itemgetter(0)))
+
+    if isinstance(items, Mapping):
+        return sort_dict(items)
+    if normalize_data and isinstance(items, (bytes, str)):
+        # Attempt to load body as JSON; not doing this by default as it could impact performance
+        try:
+            dict_items = json.loads(_decode(items))
+            dict_items = json.dumps(sort_dict(dict_items))
+            return dict_items.encode('utf-8') if isinstance(items, bytes) else dict_items
+        except Exception:
+            pass
+
+    return items
+
+
+def url_to_key(url: str, *args, **kwargs) -> str:
+    request = requests.Session().prepare_request(requests.Request('GET', url))
+    return create_key(request, *args, **kwargs)
+
+
+def _encode(value, encoding='utf-8') -> bytes:
+    """Encode a value, if it hasn't already been"""
+    return value if isinstance(value, bytes) else value.encode(encoding)
+
+
+def _decode(value, encoding='utf-8') -> str:
+    """Decode a value, if hasn't already been.
+    Note: PreparedRequest.body is always encoded in utf-8.
+    """
+    return value if isinstance(value, str) else value.decode(encoding)

--- a/requests_cache/core.py
+++ b/requests_cache/core.py
@@ -10,7 +10,7 @@ from requests import Session as OriginalSession
 from requests.hooks import dispatch_hook
 
 from . import backends
-from .backends import BaseCache, normalize_dict
+from .cache_keys import normalize_dict
 from .response import AnyResponse, ExpirationTime, set_response_defaults
 
 ALL_METHODS = ['GET', 'HEAD', 'OPTIONS', 'POST', 'PUT', 'PATCH', 'DELETE']
@@ -82,7 +82,7 @@ class CacheMixin:
         2. :py:meth:`.CachedSession.request`
         3. :py:meth:`requests.Session.request`
         4. :py:meth:`.CachedSession.send`
-        5. :py:meth:`.BaseCache.get_response`
+        5. :py:meth:`.backends.BaseCache.get_response`
         6. :py:meth:`requests.Session.send` (if not cached)
         """
         with self.request_expire_after(expire_after):
@@ -352,7 +352,7 @@ def enabled(*args, **kwargs):
         uninstall_cache()
 
 
-def get_cache() -> BaseCache:
+def get_cache() -> backends.BaseCache:
     """Returns internal cache object from globally installed ``CachedSession``"""
     return requests.Session().cache if is_installed() else None
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     author='Roman Haritonov',
     author_email='reclosedev@gmail.com',
     url='https://github.com/reclosedev/requests-cache',
-    install_requires=['requests>=2.0.0', 'itsdangerous'],
+    install_requires=['itsdangerous', 'requests>=2.0.0', 'url-normalize>=1.4'],
     extras_require=extras_require,
     include_package_data=True,
 )

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -182,6 +182,11 @@ def test_normalize_post_data(mock_session):
     assert mock_session.post(MOCKED_URL, data=sorted(params.items(), reverse=True)).from_cache is False
 
 
+# TODO
+def test_normalize_cache_key():
+    pass
+
+
 def test_delete_response(mock_session):
     mock_session.get(MOCKED_URL)
     mock_session.cache.delete_url(MOCKED_URL)


### PR DESCRIPTION
Closes #80 and #154

This PR uses [url-normalize](https://github.com/niksite/url-normalize) to improve cache keys. I think it's worth adding the extra dependency, since it's a small library (<6KB) and handles a lot of edge cases that requests-cache doesn't currently handle (resulting in duplicate cached responses in those cases).

This also adds normalization for the request `json` param, as well as JSON-formatted content in `data`.
All utilities related to creating cache keys have been moved to a separate module, `requests_cache.cache_keys`.