### PR TITLE
Switch to sphinx-material theme

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,8 +5,11 @@ sphinx:
   builder: html
   configuration: docs/conf.py
 
+build:
+  image: 8.0
+
 python:
-  version: 3.7
+  version: 3.8
   system_packages: True
   install:
     - method: pip

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,7 +106,7 @@ docker run --rm -ti \
   readthedocs/build \
   /bin/bash -c \
   "cd /home/docs/project \
-    && pip3 install '.[dev]' \
+    && pip3 install '.[docs,backends]' \
     && make -C docs html"
 ```
 

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -4,9 +4,6 @@ Advanced Usage
 ==============
 This section covers some more advanced and use-case-specific features.
 
-.. contents::
-    :local:
-
 Custom Response Filtering
 -------------------------
 If you need more advanced behavior for determining what to cache, you can provide a custom filtering

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5,9 +5,6 @@ API Reference
 =============
 This section covers all the public interfaces of requests-cache.
 
-.. contents:: Table of Contents
-    :depth: 2
-
 Sessions
 --------
 .. Explicitly show inherited method docs on CachedSession instead of CachedMixin

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,7 +31,6 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx_autodoc_typehints',
     'sphinx_copybutton',
-    'sphinx_rtd_theme',
     'sphinxcontrib.apidoc',
     'm2r2',
 ]
@@ -65,4 +64,13 @@ autosectionlabel_prefix_document = True
 
 # HTML theme settings
 pygments_style = 'sphinx'
-html_theme = 'sphinx_rtd_theme'
+html_theme = 'sphinx_material'
+html_theme_options = {
+    'color_primary': 'blue',
+    'color_accent': 'light-blue',
+    'logo_icon': '&#xe1af',
+    'repo_url': 'https://github.com/reclosedev/requests-cache',
+    'repo_name': project,
+    'nav_title': project,
+}
+html_sidebars = {'**': ['logo-text.html', 'globaltoc.html', 'localtoc.html', 'searchbox.html']}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,6 +31,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx_autodoc_typehints',
     'sphinx_copybutton',
+    'sphinx_rtd_theme',
     'sphinxcontrib.apidoc',
     'm2r2',
 ]
@@ -59,7 +60,6 @@ apidoc_module_dir = PACKAGE_DIR
 apidoc_output_dir = 'modules'
 apidoc_excluded_paths = []
 apidoc_module_first = True
-# apidoc_separate_modules = True
 apidoc_toc_file = False
 autosectionlabel_prefix_document = True
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,8 +21,8 @@ Contents
     related_projects
     history
 
-Indices and tables
-==================
+Indices and Tables
+------------------
 
 * :ref:`genindex`
 * :ref:`modindex`

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -2,10 +2,6 @@ User Guide
 ==========
 This section covers the main features of requests-cache.
 
-.. contents::
-    :local:
-    :depth: 2
-
 Installation
 ------------
 Install with pip:

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ extras_require = {
         'Sphinx~=3.5.1',
         'sphinx-autodoc-typehints',
         'sphinx-copybutton',
-        'sphinx-rtd-theme',
+        'sphinx-material',
         'sphinxcontrib-apidoc',
     ],
     # Packages used for testing both locally and in CI jobs


### PR DESCRIPTION
**TL;DR:** I'm switching the Sphinx docs to use the [sphinx-material theme](https://bashtage.github.io/sphinx-material/index.html) due to a possible issue with sphinx-rtd-theme. Any other suggestions would be appreciated for how to fix the issue below, or on documentation formatting/theming in general.

For some weird reason, there is currently an issue with the requests-cache docs using sphinx-rtd-theme on readthedocs. It causes almost all bullet lists to not render correctly, which is kind of a dealbreaker:
![image](https://user-images.githubusercontent.com/419936/113495886-304b4800-94ba-11eb-8295-1faf47fa0ba2.png)

The same section in sphinx-material, for comparison:
![image](https://user-images.githubusercontent.com/419936/113495951-9932c000-94ba-11eb-95c4-c67e7b69d404.png)

The docs look just fine when built locally, but not on readthedocs, specifically with sphinx-rtd-theme. They look fine on readthedocs with any other theme. I used the `readthedocs/build` docker image and tried various combinations of different versions of the build environment, Sphinx, sphinx-rtd-theme, and other Sphinx extensions, as well as reverting recent changes, but couldn't get the docs to render correctly.

Personally I like the material theme (and it has the advantage of looking, but I'm not sure how others feel about it. If anyone has strong opinions about it, we can switch back to sphinx-rtd-theme if/when this issue is fixed.