### PR TITLE
Add optional support for pytest-httpbin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,16 +58,30 @@ $ pre-commit uninstall
 * Run `./runtests.sh` to run all tests with some useful options for test coverage reports,
   multiprocessing, and debugging.
 
-### Integration Tests
-Live databases are required to run integration tests, and docker-compose config is included to make
-this easier. First, [install docker](https://docs.docker.com/get-docker/) and
-[install docker-compose](https://docs.docker.com/compose/install/).
+### Integration Test Containers
+A live web server and backend databases are required to run integration tests, and docker-compose
+config is included to make this easier. First, [install docker](https://docs.docker.com/get-docker/)
+and [install docker-compose](https://docs.docker.com/compose/install/).
 
 Then, run:
 ```bash
 $ docker-compose up -d
 pytest tests/integration
 ```
+
+### Integration Test Alternatives
+If you can't easily run Docker containers in your environment but still want to run some of the
+integration tests, you can use [pytest-httpbin](https://github.com/kevin1024/pytest-httpbin) instead
+of the httpbin container. This just requires installing an extra package and setting an environment
+variable:
+```bash
+pip install pytest-httpbin
+export USE_PYTEST_HTTPBIN=true
+pytest tests/integration/test_cache.py
+```
+
+For backend databases, you can install and run them on the host instead of in a container, as long
+as they are running on the default port.
 
 ## Debugging
 When you run into issues while working on new features and/or tests, it will make your life much easier

--- a/tests/integration/test_cache.py
+++ b/tests/integration/test_cache.py
@@ -2,7 +2,7 @@
 import json
 import pytest
 
-from tests.conftest import httpbin
+from tests.conftest import USE_PYTEST_HTTPBIN, httpbin
 
 HTTPBIN_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE']
 HTTPBIN_FORMATS = [
@@ -37,6 +37,10 @@ def test_all_methods(field, method, tempfile_session):
 @pytest.mark.parametrize('response_format', HTTPBIN_FORMATS)
 def test_all_response_formats(response_format, tempfile_session):
     """Test that all relevant response formats are cached correctly"""
+    # Temporary workaround for this issue: https://github.com/kevin1024/pytest-httpbin/issues/60
+    if response_format == 'json' and USE_PYTEST_HTTPBIN:
+        tempfile_session.allowable_codes = (200, 404)
+
     r1 = tempfile_session.get(httpbin(response_format))
     r2 = tempfile_session.get(httpbin(response_format))
     assert r1.from_cache is False


### PR DESCRIPTION
This is mainly to make it easier to run a subset of integration tests for RPM package maintainers, or other environments where Docker isn't a viable option. See issue #221.

Usage example (also added to CONTRIBUTING.md):
```bash
pip install pytest-httpbin
export USE_PYTEST_HTTPBIN=true
pytest tests/integration/test_cache.py
```

Other changes:
* Configure logging to show debug output when tests fail (or with `pytest -s`)
* Encountered one minor issue with pytest-httpbin with an easy workaround; made issue https://github.com/kevin1024/pytest-httpbin/issues/60 for this