### PR TITLE
Add & update backend integration tests

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,8 @@
 * Add recently renamed `BaseCache.remove_old_entries()` back, as an alias with a DeprecationWarning
 * Make parent dirs for new SQLite databases
 * Exclude test directory from `find_packages()`
+* Add `aws_access_key_id` and `aws_secret_access_key` kwargs to `DynamoDbDict`
+* Update `GridFSPickleDict.__delitem__` to raise a KeyError for missing items
 
 ## 0.6.0 (2021-04-09)
 [See all included issues and PRs](https://github.com/reclosedev/requests-cache/milestone/1?closed=1)

--- a/requests_cache/backends/__init__.py
+++ b/requests_cache/backends/__init__.py
@@ -42,28 +42,28 @@ def get_placeholder_backend(original_exception: Exception = None) -> Type[BaseCa
     return PlaceholderBackend
 
 
-# Import all backends for which dependencies are installed
+# Import all backend classes for which dependencies are installed
 try:
-    from .dynamodb import DynamoDbCache
+    from .dynamodb import DynamoDbCache, DynamoDbDict
 except ImportError as e:
-    DynamoDbCache = get_placeholder_backend(e)  # type: ignore
+    DynamoDbCache = DynamoDbDict = get_placeholder_backend(e)  # type: ignore
 try:
-    from .gridfs import GridFSCache
+    from .gridfs import GridFSCache, GridFSPickleDict
 except ImportError as e:
-    GridFSCache = get_placeholder_backend(e)  # type: ignore
+    GridFSCache = GridFSPickleDict = get_placeholder_backend(e)  # type: ignore
 try:
-    from .mongo import MongoCache
+    from .mongo import MongoCache, MongoDict, MongoPickleDict
 except ImportError as e:
-    MongoCache = get_placeholder_backend(e)  # type: ignore
+    MongoCache = MongoDict = MongoPickleDict = get_placeholder_backend(e)  # type: ignore
 try:
-    from .redis import RedisCache
+    from .redis import RedisCache, RedisDict
 except ImportError as e:
-    RedisCache = get_placeholder_backend(e)  # type: ignore
+    RedisCache = RedisDict = get_placeholder_backend(e)  # type: ignore
 try:
     # Note: Heroku doesn't support SQLite due to ephemeral storage
-    from .sqlite import DbCache
+    from .sqlite import DbCache, DbDict, DbPickleDict
 except ImportError as e:
-    DbCache = get_placeholder_backend(e)  # type: ignore
+    DbCache = DbDict = DbPickleDict = get_placeholder_backend(e)  # type: ignore
 
 
 BACKEND_CLASSES = {

--- a/requests_cache/backends/dynamodb.py
+++ b/requests_cache/backends/dynamodb.py
@@ -44,6 +44,8 @@ class DynamoDbDict(BaseStorage):
         connection=None,
         endpoint_url=None,
         region_name='us-east-1',
+        aws_access_key_id=None,
+        aws_secret_access_key=None,
         read_capacity_units=1,
         write_capacity_units=1,
         **kwargs,
@@ -53,7 +55,15 @@ class DynamoDbDict(BaseStorage):
         if connection is not None:
             self.connection = connection
         else:
-            self.connection = boto3.resource('dynamodb', endpoint_url=endpoint_url, region_name=region_name)
+            # TODO: Use inspection to get any valid resource arguments from **kwargs
+            self.connection = boto3.resource(
+                'dynamodb',
+                endpoint_url=endpoint_url,
+                region_name=region_name,
+                aws_access_key_id=aws_access_key_id,
+                aws_secret_access_key=aws_secret_access_key,
+            )
+
         try:
             self.connection.create_table(
                 AttributeDefinitions=[

--- a/requests_cache/backends/gridfs.py
+++ b/requests_cache/backends/gridfs.py
@@ -31,7 +31,7 @@ class GridFSCache(BaseCache):
 class GridFSPickleDict(BaseStorage):
     """A dictionary-like interface for a GridFS collection"""
 
-    def __init__(self, db_name, connection=None, **kwargs):
+    def __init__(self, db_name, collection_name=None, connection=None, **kwargs):
         """
         :param db_name: database name (be careful with production databases)
         :param connection: ``pymongo.Connection`` instance. If it's ``None``
@@ -54,13 +54,17 @@ class GridFSPickleDict(BaseStorage):
         return self.deserialize(result.read())
 
     def __setitem__(self, key, item):
-        self.__delitem__(key)
+        try:
+            self.__delitem__(key)
+        except KeyError:
+            pass
         self.fs.put(self.serialize(item), **{'_id': key})
 
     def __delitem__(self, key):
         res = self.fs.find_one({'_id': key})
-        if res is not None:
-            self.fs.delete(res._id)
+        if res is None:
+            raise KeyError
+        self.fs.delete(res._id)
 
     def __len__(self):
         return self.db['fs.files'].count()

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ extras_require = {
         'pytest-xdist',
         'radon',
         'requests-mock>=1.8',
+        'timeout-decorator',
     ],
 }
 # All development/testing packages combined

--- a/tests/integration/test_backends.py
+++ b/tests/integration/test_backends.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # TODO: Refactor with pytest fixtures
 import os
 

--- a/tests/integration/test_backends.py
+++ b/tests/integration/test_backends.py
@@ -1,76 +1,78 @@
 # TODO: Refactor with pytest fixtures
-import os
+import pytest
+from typing import Type
 
 from requests_cache.backends.base import BaseStorage
-from requests_cache.backends.sqlite import DbDict, DbPickleDict
 
 
-class BaseBackendTestCase:
+class BaseStorageTestCase:
     """Base class for testing backends"""
 
-    dict_class: BaseStorage = DbDict
-    pickled_dict_class: BaseStorage = DbPickleDict
+    def __init__(
+        self,
+        *args,
+        storage_class: Type[BaseStorage],
+        picklable: bool = False,
+        **kwargs,
+    ):
+        self.storage_class = storage_class
+        self.picklable = picklable
+        super().__init__(*args, **kwargs)
 
-    NAMESPACE = 'requests-cache-temporary-db-test-will-be-deleted'
+    NAMESPACE = 'pytest-temp'
     TABLES = ['table%s' % i for i in range(5)]
 
     def tearDown(self):
-        if self.dict_class is DbDict:
-            try:
-                os.unlink(self.NAMESPACE)
-            except Exception:
-                pass
-            return
         for table in self.TABLES:
-            d = self.dict_class(self.NAMESPACE, table)
-            d.clear()
+            self.storage_class(self.NAMESPACE, table).clear()
         super().tearDown()
 
     def test_set_get(self):
-        d1 = self.dict_class(self.NAMESPACE, self.TABLES[0])
-        d2 = self.dict_class(self.NAMESPACE, self.TABLES[1])
-        d3 = self.dict_class(self.NAMESPACE, self.TABLES[2])
+        d1 = self.storage_class(self.NAMESPACE, self.TABLES[0])
+        d2 = self.storage_class(self.NAMESPACE, self.TABLES[1])
+        d3 = self.storage_class(self.NAMESPACE, self.TABLES[2])
         d1[1] = 1
         d2[2] = 2
         d3[3] = 3
-        self.assertEqual(list(d1.keys()), [1])
-        self.assertEqual(list(d2.keys()), [2])
-        self.assertEqual(list(d3.keys()), [3])
+        assert list(d1.keys()) == [1]
+        assert list(d2.keys()) == [2]
+        assert list(d3.keys()) == [3]
 
-        with self.assertRaises(KeyError):
+        with pytest.raises(KeyError):
             d1[4]
 
     def test_str(self):
-        d = self.dict_class(self.NAMESPACE)
+        d = self.storage_class(self.NAMESPACE)
         d.clear()
         d[1] = 1
         d[2] = 2
-        self.assertEqual(str(d), '{1: 1, 2: 2}')
+        assert d == {1: 1, 2: 2}
 
     def test_del(self):
-        d = self.dict_class(self.NAMESPACE)
+        d = self.storage_class(self.NAMESPACE)
         d.clear()
         for i in range(5):
             d[i] = i
         del d[0]
         del d[1]
         del d[2]
-        self.assertEqual(list(d.keys()), list(range(3, 5)))
-        self.assertEqual(list(d.values()), list(range(3, 5)))
+        assert list(d.keys()) == list(range(3, 5))
+        assert list(d.values()) == list(range(3, 5))
 
-        with self.assertRaises(KeyError):
+        with pytest.raises(KeyError):
             del d[0]
 
     def test_picklable_dict(self):
-        d = self.pickled_dict_class(self.NAMESPACE)
-        d[1] = ForPickle()
-        d = self.pickled_dict_class(self.NAMESPACE)
-        self.assertEqual(d[1].a, 1)
-        self.assertEqual(d[1].b, 2)
+        if self.picklable:
+            d = self.storage_class(self.NAMESPACE)
+            d[1] = Picklable()
+            d = self.storage_class(self.NAMESPACE)
+            assert d[1].a == 1
+            assert d[1].b == 2
 
     def test_clear_and_work_again(self):
-        d1 = self.dict_class(self.NAMESPACE)
-        d2 = self.pickled_dict_class(self.NAMESPACE, connection=d1.connection)
+        d1 = self.storage_class(self.NAMESPACE)
+        d2 = self.storage_class(self.NAMESPACE, connection=d1.connection)
         d1.clear()
         d2.clear()
 
@@ -84,8 +86,8 @@ class BaseBackendTestCase:
         assert len(d1) == len(d2) == 0
 
     def test_same_settings(self):
-        d1 = self.dict_class(self.NAMESPACE)
-        d2 = self.dict_class(self.NAMESPACE, connection=d1.connection)
+        d1 = self.storage_class(self.NAMESPACE)
+        d2 = self.storage_class(self.NAMESPACE, connection=d1.connection)
         d1.clear()
         d2.clear()
         d1[1] = 1
@@ -93,6 +95,6 @@ class BaseBackendTestCase:
         assert d1 == d2
 
 
-class ForPickle(object):
+class Picklable:
     a = 1
     b = 2

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -1,26 +1,34 @@
-#!/usr/bin/env python
-import os
+import pytest
 import unittest
 
+from requests_cache.backends import DynamoDbDict
+from tests.conftest import fail_if_no_connection
 from tests.integration.test_backends import BaseBackendTestCase
 
-try:
-    from requests_cache.backends.dynamodb import DynamoDbDict
-except ImportError:
-    print("DynamoDb not installed")
-else:
-    # boto3 will accept any values for creds, but they still need to be present
-    os.environ['AWS_ACCESS_KEY_ID'] = 'placeholder'
-    os.environ['AWS_SECRET_ACCESS_KEY'] = 'placeholder'
+boto_options = {
+    'endpoint_url': 'http://localhost:8000',
+    'region_name': 'us-east-1',
+    'aws_access_key_id': 'placeholder',
+    'aws_secret_access_key': 'placeholder',
+}
 
-    class DynamoDbDictWrapper(DynamoDbDict):
-        def __init__(self, namespace, collection_name='dynamodb_dict_data', **options):
-            options['endpoint_url'] = 'http://0.0.0.0:8000'
-            super().__init__(namespace, collection_name, **options)
 
-    class DynamoDbTestCase(BaseBackendTestCase, unittest.TestCase):
-        dict_class = DynamoDbDictWrapper
-        pickled_dict_class = DynamoDbDictWrapper
+@pytest.fixture(scope='module', autouse=True)
+@fail_if_no_connection
+def ensure_connection():
+    """Fail all tests in this module if DynamoDB is not running"""
+    import boto3
 
-    if __name__ == '__main__':
-        unittest.main()
+    client = boto3.client('dynamodb', **boto_options)
+    client.describe_limits()
+
+
+class DynamoDbDictWrapper(DynamoDbDict):
+    def __init__(self, namespace, collection_name='dynamodb_dict_data', **options):
+        options.update(boto_options)
+        super().__init__(namespace, collection_name, **options)
+
+
+class DynamoDbTestCase(BaseBackendTestCase, unittest.TestCase):
+    dict_class = DynamoDbDictWrapper
+    pickled_dict_class = DynamoDbDictWrapper

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -3,7 +3,7 @@ import unittest
 
 from requests_cache.backends import DynamoDbDict
 from tests.conftest import fail_if_no_connection
-from tests.integration.test_backends import BaseBackendTestCase
+from tests.integration.test_backends import BaseStorageTestCase
 
 boto_options = {
     'endpoint_url': 'http://localhost:8000',
@@ -25,10 +25,14 @@ def ensure_connection():
 
 class DynamoDbDictWrapper(DynamoDbDict):
     def __init__(self, namespace, collection_name='dynamodb_dict_data', **options):
-        options.update(boto_options)
-        super().__init__(namespace, collection_name, **options)
+        super().__init__(namespace, collection_name, **options, **boto_options)
 
 
-class DynamoDbTestCase(BaseBackendTestCase, unittest.TestCase):
-    dict_class = DynamoDbDictWrapper
-    pickled_dict_class = DynamoDbDictWrapper
+class DynamoDbTestCase(BaseStorageTestCase, unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(
+            *args,
+            storage_class=DynamoDbDictWrapper,
+            picklable=True,
+            **kwargs,
+        )

--- a/tests/integration/test_gridfs.py
+++ b/tests/integration/test_gridfs.py
@@ -1,19 +1,21 @@
-#!/usr/bin/env python
+import pytest
 import unittest
 
+from requests_cache.backends import GridFSPickleDict, MongoDict
+from tests.conftest import fail_if_no_connection
 from tests.integration.test_backends import BaseBackendTestCase
 
-try:
-    from requests_cache.backends.gridfs import GridFSPickleDict
-    from requests_cache.backends.mongo import MongoDict
 
-except ImportError:
-    print("pymongo not installed")
-else:
+@pytest.fixture(scope='module', autouse=True)
+@fail_if_no_connection
+def ensure_connection():
+    """Fail all tests in this module if MongoDB is not running"""
+    from pymongo import MongoClient
 
-    class GridFSTestCase(BaseBackendTestCase, unittest.TestCase):
-        dict_class = MongoDict
-        pickled_dict_class = GridFSPickleDict
+    client = MongoClient(serverSelectionTimeoutMS=200)
+    client.server_info()
 
-    if __name__ == '__main__':
-        unittest.main()
+
+class GridFSTestCase(BaseBackendTestCase, unittest.TestCase):
+    dict_class = MongoDict
+    pickled_dict_class = GridFSPickleDict

--- a/tests/integration/test_gridfs.py
+++ b/tests/integration/test_gridfs.py
@@ -1,9 +1,9 @@
 import pytest
 import unittest
 
-from requests_cache.backends import GridFSPickleDict, MongoDict
+from requests_cache.backends import GridFSPickleDict
 from tests.conftest import fail_if_no_connection
-from tests.integration.test_backends import BaseBackendTestCase
+from tests.integration.test_backends import BaseStorageTestCase
 
 
 @pytest.fixture(scope='module', autouse=True)
@@ -16,6 +16,16 @@ def ensure_connection():
     client.server_info()
 
 
-class GridFSTestCase(BaseBackendTestCase, unittest.TestCase):
-    dict_class = MongoDict
-    pickled_dict_class = GridFSPickleDict
+class GridFSPickleDictTestCase(BaseStorageTestCase, unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, storage_class=GridFSPickleDict, picklable=True, **kwargs)
+
+    def test_set_get(self):
+        """Override base test to test a single collecton instead of multiple"""
+        d1 = self.storage_class(self.NAMESPACE, self.TABLES[0])
+        d1[1] = 1
+        d1[2] = 2
+        assert list(d1.keys()) == [1, 2]
+
+        with pytest.raises(KeyError):
+            d1[4]

--- a/tests/integration/test_mongodb.py
+++ b/tests/integration/test_mongodb.py
@@ -1,17 +1,21 @@
-#!/usr/bin/env python
+import pytest
 import unittest
 
+from requests_cache.backends import MongoDict, MongoPickleDict
+from tests.conftest import fail_if_no_connection
 from tests.integration.test_backends import BaseBackendTestCase
 
-try:
-    from requests_cache.backends.mongo import MongoDict, MongoPickleDict
-except ImportError:
-    print("pymongo not installed")
-else:
 
-    class MongoDBTestCase(BaseBackendTestCase, unittest.TestCase):
-        dict_class = MongoDict
-        pickled_dict_class = MongoPickleDict
+@pytest.fixture(scope='module', autouse=True)
+@fail_if_no_connection
+def ensure_connection():
+    """Fail all tests in this module if MongoDB is not running"""
+    from pymongo import MongoClient
 
-    if __name__ == '__main__':
-        unittest.main()
+    client = MongoClient(serverSelectionTimeoutMS=200)
+    client.server_info()
+
+
+class MongoDBTestCase(BaseBackendTestCase, unittest.TestCase):
+    dict_class = MongoDict
+    pickled_dict_class = MongoPickleDict

--- a/tests/integration/test_mongodb.py
+++ b/tests/integration/test_mongodb.py
@@ -3,7 +3,7 @@ import unittest
 
 from requests_cache.backends import MongoDict, MongoPickleDict
 from tests.conftest import fail_if_no_connection
-from tests.integration.test_backends import BaseBackendTestCase
+from tests.integration.test_backends import BaseStorageTestCase
 
 
 @pytest.fixture(scope='module', autouse=True)
@@ -16,6 +16,11 @@ def ensure_connection():
     client.server_info()
 
 
-class MongoDBTestCase(BaseBackendTestCase, unittest.TestCase):
-    dict_class = MongoDict
-    pickled_dict_class = MongoPickleDict
+class MongoDictTestCase(BaseStorageTestCase, unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, storage_class=MongoDict, **kwargs)
+
+
+class MongoPickleDictTestCase(BaseStorageTestCase, unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, storage_class=MongoPickleDict, picklable=True, **kwargs)

--- a/tests/integration/test_redis.py
+++ b/tests/integration/test_redis.py
@@ -3,7 +3,7 @@ import unittest
 
 from requests_cache.backends.redis import RedisDict
 from tests.conftest import fail_if_no_connection
-from tests.integration.test_backends import BaseBackendTestCase
+from tests.integration.test_backends import BaseStorageTestCase
 
 
 @pytest.fixture(scope='module', autouse=True)
@@ -15,6 +15,6 @@ def ensure_connection():
     Redis().info()
 
 
-class RedisTestCase(BaseBackendTestCase, unittest.TestCase):
-    dict_class = RedisDict
-    pickled_dict_class = RedisDict
+class RedisTestCase(BaseStorageTestCase, unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, storage_class=RedisDict, picklable=True, **kwargs)

--- a/tests/integration/test_redis.py
+++ b/tests/integration/test_redis.py
@@ -1,17 +1,20 @@
-#!/usr/bin/env python
+import pytest
 import unittest
 
+from requests_cache.backends.redis import RedisDict
+from tests.conftest import fail_if_no_connection
 from tests.integration.test_backends import BaseBackendTestCase
 
-try:
-    from requests_cache.backends.redis import RedisDict
-except ImportError:
-    print("Redis not installed")
-else:
 
-    class RedisTestCase(BaseBackendTestCase, unittest.TestCase):
-        dict_class = RedisDict
-        pickled_dict_class = RedisDict
+@pytest.fixture(scope='module', autouse=True)
+@fail_if_no_connection
+def ensure_connection():
+    """Fail all tests in this module if Redis is not running"""
+    from redis import Redis
 
-    if __name__ == '__main__':
-        unittest.main()
+    Redis().info()
+
+
+class RedisTestCase(BaseBackendTestCase, unittest.TestCase):
+    dict_class = RedisDict
+    pickled_dict_class = RedisDict

--- a/tests/integration/test_sqlite.py
+++ b/tests/integration/test_sqlite.py
@@ -1,15 +1,21 @@
-#!/usr/bin/env python
+import os
 import unittest
 from threading import Thread
 from unittest.mock import patch
 
 from requests_cache.backends.sqlite import DbDict, DbPickleDict
-from tests.integration.test_backends import BaseBackendTestCase
+from tests.integration.test_backends import BaseStorageTestCase
 
 
-class DbdictTestCase(BaseBackendTestCase, unittest.TestCase):
+class SQLiteTestCase(BaseStorageTestCase):
+    def tearDown(self):
+        try:
+            os.unlink(self.NAMESPACE)
+        except Exception:
+            pass
+
     def test_bulk_commit(self):
-        d = DbDict(self.NAMESPACE, self.TABLES[0])
+        d = self.storage_class(self.NAMESPACE, self.TABLES[0])
         with d.bulk_commit():
             pass
         d.clear()
@@ -17,46 +23,41 @@ class DbdictTestCase(BaseBackendTestCase, unittest.TestCase):
         with d.bulk_commit():
             for i in range(n):
                 d[i] = i
-        self.assertEqual(list(d.keys()), list(range(n)))
+        assert list(d.keys()) == list(range(n))
 
     def test_switch_commit(self):
-        d = DbDict(self.NAMESPACE)
+        d = self.storage_class(self.NAMESPACE)
         d.clear()
         d[1] = 1
-        d = DbDict(self.NAMESPACE)
-        self.assertIn(1, d)
+        d = self.storage_class(self.NAMESPACE)
+        assert 1 in d
 
         d._can_commit = False
         d[2] = 2
 
-        d = DbDict(self.NAMESPACE)
-        self.assertNotIn(2, d)
-        self.assertTrue(d._can_commit)
+        d = self.storage_class(self.NAMESPACE)
+        assert 2 not in d
+        assert d._can_commit is True
 
     def test_fast_save(self):
-        d1 = DbDict(self.NAMESPACE, fast_save=True)
-        d2 = DbDict(self.NAMESPACE, self.TABLES[1], fast_save=True)
+        d1 = self.storage_class(self.NAMESPACE, fast_save=True)
+        d2 = self.storage_class(self.NAMESPACE, self.TABLES[1], fast_save=True)
         d1.clear()
         n = 1000
         for i in range(n):
             d1[i] = i
             d2[i * 2] = i
         # HACK if we will not sort, fast save can produce different order of records
-        self.assertEqual(sorted(d1.keys()), list(range(n)))
-        self.assertEqual(sorted(d2.values()), list(range(n)))
+        assert sorted(d1.keys()) == list(range(n))
+        assert sorted(d2.values()) == list(range(n))
 
     def test_usage_with_threads(self):
         def do_test_for(d, n_threads=5):
             d.clear()
-            fails = []
 
             def do_inserts(values):
-                try:
-                    for v in values:
-                        d[v] = v
-                except Exception:
-                    fails.append(1)
-                    raise
+                for v in values:
+                    d[v] = v
 
             def values(x, n):
                 return [i * x for i in range(n)]
@@ -67,18 +68,24 @@ class DbdictTestCase(BaseBackendTestCase, unittest.TestCase):
             for t in threads:
                 t.join()
 
-            self.assertFalse(fails)
             for i in range(n_threads):
                 for x in values(i, n_threads):
-                    self.assertEqual(d[x], x)
+                    assert d[x] == x
 
-        do_test_for(DbDict(self.NAMESPACE, fast_save=True), 20)
-        do_test_for(DbPickleDict(self.NAMESPACE, fast_save=True), 10)
-        d1 = DbDict(self.NAMESPACE, fast_save=True)
-        d2 = DbDict(self.NAMESPACE, self.TABLES[1], fast_save=True)
-        do_test_for(d1)
-        do_test_for(d2)
-        do_test_for(DbDict(self.NAMESPACE))
+        do_test_for(self.storage_class(self.NAMESPACE))
+        do_test_for(self.storage_class(self.NAMESPACE, fast_save=True), 20)
+        do_test_for(self.storage_class(self.NAMESPACE, fast_save=True))
+        do_test_for(self.storage_class(self.NAMESPACE, self.TABLES[1], fast_save=True))
+
+
+class DbDictTestCase(SQLiteTestCase, unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, storage_class=DbDict, **kwargs)
+
+
+class DbPickleDictTestCase(SQLiteTestCase, unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, storage_class=DbPickleDict, picklable=True, **kwargs)
 
 
 @patch('requests_cache.backends.sqlite.sqlite3')
@@ -86,7 +93,3 @@ def test_timeout(mock_sqlite):
     """Just make sure the optional 'timeout' param gets passed to sqlite3.connect"""
     DbDict('test', timeout=0.5)
     mock_sqlite.connect.assert_called_with('test', timeout=0.5)
-
-
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
This will address just a couple of the items from #212.

* Update all backend-specific integration tests to fail quickly if not set up, rarther than silently ignoring or hanging
* Add one test case per backend storage class
* Add `aws_access_key_id` and `aws_secret_access_key` kwargs to `DynamoDbDict`
  * Made a separate issue to handle this generically for all backends: #229
* Update `GridFSPickleDict.__delitem__` to raise a KeyError for missing items
