### PR TITLE
Fix handling of decode_content parameter for raw.read(...)

### DIFF
--- a/requests_cache/response.py
+++ b/requests_cache/response.py
@@ -52,16 +52,16 @@ class CachedResponse(Response):
 
         # Read content to support streaming requests, and reset file pointer on original request
         if hasattr(original_response.raw, '_fp') and not original_response.raw.isclosed():
-            # Cache raw data in `_body`
-            original_response.raw.read(decode_content=False, cache_content=True)
+            # Cache raw data
+            raw_data = original_response.raw.read(decode_content=False)
             # Reset `_fp`
-            original_response.raw._fp = BytesIO(original_response.raw._body)
+            original_response.raw._fp = BytesIO(raw_data)
             # Read and store (decoded) data
             self._content = original_response.content
             # Reset `_fp` again
-            original_response.raw._fp = BytesIO(original_response.raw._body)
+            original_response.raw._fp = BytesIO(raw_data)
             original_response.raw._fp_bytes_read = 0
-            original_response.raw.length_remaining = len(original_response.raw._body)
+            original_response.raw.length_remaining = len(raw_data)
         else:
             self._content = original_response.content
 

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -6,7 +6,7 @@ from time import sleep
 from urllib3.response import HTTPResponse
 
 from requests_cache import CachedHTTPResponse, CachedResponse
-from tests.conftest import MOCKED_URL, httpbin
+from tests.conftest import MOCKED_URL
 
 
 def test_basic_attrs(mock_session):
@@ -69,26 +69,6 @@ def test_raw_response__reset(mock_session):
 
     response.reset()
     assert response.raw.read(None) == b'mock response'
-
-
-def test_raw_response__decode(tempfile_session):
-    """Test that a gzip-compressed raw response can be manually uncompressed with decode_content"""
-    response = tempfile_session.get(httpbin('gzip'))
-    assert b'gzipped' in response.content
-
-    cached = CachedResponse(response)
-    assert b'gzipped' in cached.content
-    assert b'gzipped' in cached.raw.read(None, decode_content=True)
-
-
-def test_raw_response__decode_stream(tempfile_session):
-    """Test that streamed gzip-compressed responses can be uncompressed with decode_content"""
-    response_uncached = tempfile_session.get(httpbin('gzip'), stream=True)
-    response_cached = tempfile_session.get(httpbin('gzip'), stream=True)
-
-    for res in (response_uncached, response_cached):
-        assert b'gzipped' in res.content
-        assert b'gzipped' in res.raw.read(None, decode_content=True)
 
 
 def test_raw_response__stream(mock_session):


### PR DESCRIPTION
(fixes #232)

Previously, calling `response.raw.read` on encoded responses with `decode_content=False` would (incorrectly) return decoded data, and `decode_content=True` would result in an empty return value or an exception (caused by trying to decode twice).

This change attempts to fix this for the original request that gets modified by `CachedResponse`, by patching `raw.read` to always use `decode_content=False` regardless of the parameter value; this feels kind of hacky (because it is), but I honestly couldn't think of a better way that didn't involve monkey-patching some method of `original_response.raw`.  
The `read` method of `CachedHTTPResponse` is changed in a similar way, discarding the `decode_content` parameter altogether and always returning decoded data directly.  
It should also log a warning if encoded data would have normally been returned.

Let me know if there's anything I missed, especially since I'm not too familiar with pytest.