### PR TITLE
Allow passing any valid backend connection kwargs via BaseCache

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,6 +26,7 @@ templates_path = ['_templates']
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosectionlabel',
+    'sphinx.ext.extlinks',
     'sphinx.ext.intersphinx',
     'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',
@@ -40,9 +41,16 @@ exclude_patterns = ['_build', 'modules/requests_cache.rst']
 
 # Enable automatic links to other projects' Sphinx docs
 intersphinx_mapping = {
+    'boto3': ('https://boto3.amazonaws.com/v1/documentation/api/latest/', None),
+    'botocore': ('http://botocore.readthedocs.io/en/latest/', None),
+    'pymongo': ('https://pymongo.readthedocs.io/en/stable/', None),
     'python': ('https://docs.python.org/3', None),
+    'redis': ('https://redis-py.readthedocs.io/en/stable/', None),
     'requests': ('https://docs.python-requests.org/en/master/', None),
     'urllib3': ('https://urllib3.readthedocs.io/en/latest/', None),
+}
+extlinks = {
+    'boto3': ('https://boto3.amazonaws.com/v1/documentation/api/latest/reference/%s', None),
 }
 
 # Enable Google-style docstrings

--- a/requests_cache/backends/__init__.py
+++ b/requests_cache/backends/__init__.py
@@ -1,7 +1,8 @@
 """Classes and functions for cache persistence"""
 # flake8: noqa: F401
+from inspect import signature
 from logging import getLogger
-from typing import Type, Union
+from typing import Callable, Dict, Iterable, Type, Union
 
 from .base import BaseCache, BaseStorage
 
@@ -40,6 +41,13 @@ def get_placeholder_backend(original_exception: Exception = None) -> Type[BaseCa
             raise original_exception or ImportError(msg)
 
     return PlaceholderBackend
+
+
+def get_valid_kwargs(func: Callable, kwargs: Dict, extras: Iterable[str] = None) -> Dict:
+    """Get the subset of non-None ``kwargs`` that are valid params for ``func``"""
+    params = list(signature(func).parameters)
+    params.extend(extras or [])
+    return {k: v for k, v in kwargs.items() if k in params and v is not None}
 
 
 # Import all backend classes for which dependencies are installed

--- a/requests_cache/backends/base.py
+++ b/requests_cache/backends/base.py
@@ -2,7 +2,7 @@ import pickle
 import warnings
 from abc import ABC
 from collections.abc import MutableMapping
-from logging import getLogger
+from logging import DEBUG, WARNING, getLogger
 from typing import Iterable, List, Tuple, Union
 
 import requests
@@ -177,14 +177,9 @@ class BaseStorage(MutableMapping, ABC):
         self._serializer = serializer or self._get_serializer(secret_key, salt)
         logger.debug(f'Initializing {type(self).__name__} with serializer: {self._serializer}')
 
-        # Show a warning instead of an exception if there are remaining unused kwargs
-        kwargs.pop('include_get_headers', None)
-        kwargs.pop('ignored_params', None)
-        if kwargs:
-            logger.warning(f'Unrecognized keyword arguments: {kwargs}')
         if not secret_key:
-            warn_func = logger.debug if suppress_warnings else warnings.warn
-            warn_func('Using a secret key to sign cached items is recommended for this backend')
+            level = DEBUG if suppress_warnings else WARNING
+            logger.log(level, 'Using a secret key is recommended for this backend')
 
     def serialize(self, item: ResponseOrKey) -> bytes:
         """Serialize a URL or response into bytes"""

--- a/requests_cache/session.py
+++ b/requests_cache/session.py
@@ -9,7 +9,7 @@ from requests import PreparedRequest
 from requests import Session as OriginalSession
 from requests.hooks import dispatch_hook
 
-from .backends import BACKEND_KWARGS, BackendSpecifier, init_backend
+from .backends import BackendSpecifier, get_valid_kwargs, init_backend
 from .cache_keys import normalize_dict
 from .response import AnyResponse, ExpirationTime, set_response_defaults
 
@@ -47,8 +47,8 @@ class CacheMixin:
         self._disabled = False
         self._lock = RLock()
 
-        # Remove any requests-cache-specific kwargs before passing along to superclass
-        session_kwargs = {k: v for k, v in kwargs.items() if k not in BACKEND_KWARGS}
+        # If the superclass is custom Session, pass along valid kwargs (if any)
+        session_kwargs = get_valid_kwargs(super().__init__, kwargs)
         super().__init__(**session_kwargs)
 
     def request(

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -1,5 +1,6 @@
 import pytest
 import unittest
+from unittest.mock import patch
 
 from requests_cache.backends import DynamoDbDict
 from tests.conftest import fail_if_no_connection
@@ -39,3 +40,10 @@ class DynamoDbTestCase(BaseStorageTestCase, unittest.TestCase):
             picklable=True,
             **kwargs,
         )
+
+
+@patch('requests_cache.backends.dynamodb.boto3.resource')
+def test_connection_kwargs(mock_resource):
+    """A spot check to make sure optional connection kwargs gets passed to connection"""
+    DynamoDbDict('test', region_name='us-east-2', invalid_kwarg='???')
+    mock_resource.assert_called_with('dynamodb', region_name='us-east-2')

--- a/tests/integration/test_mongodb.py
+++ b/tests/integration/test_mongodb.py
@@ -1,7 +1,10 @@
 import pytest
 import unittest
+from unittest.mock import patch
 
-from requests_cache.backends import MongoDict, MongoPickleDict
+from pymongo import MongoClient
+
+from requests_cache.backends import MongoDict, MongoPickleDict, get_valid_kwargs
 from tests.conftest import fail_if_no_connection
 from tests.integration.test_backends import BaseStorageTestCase
 
@@ -24,3 +27,14 @@ class MongoDictTestCase(BaseStorageTestCase, unittest.TestCase):
 class MongoPickleDictTestCase(BaseStorageTestCase, unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, storage_class=MongoPickleDict, picklable=True, **kwargs)
+
+
+@patch('requests_cache.backends.mongo.MongoClient')
+@patch(
+    'requests_cache.backends.mongo.get_valid_kwargs',
+    side_effect=lambda cls, kwargs: get_valid_kwargs(MongoClient, kwargs),
+)
+def test_connection_kwargs(mock_get_valid_kwargs, mock_client):
+    """A spot check to make sure optional connection kwargs gets passed to connection"""
+    MongoDict('test', host='http://0.0.0.0', port=1234, invalid_kwarg='???')
+    mock_client.assert_called_with(host='http://0.0.0.0', port=1234)

--- a/tests/integration/test_redis.py
+++ b/tests/integration/test_redis.py
@@ -1,7 +1,8 @@
 import pytest
 import unittest
+from unittest.mock import patch
 
-from requests_cache.backends.redis import RedisDict
+from requests_cache.backends.redis import RedisCache, RedisDict
 from tests.conftest import fail_if_no_connection
 from tests.integration.test_backends import BaseStorageTestCase
 
@@ -18,3 +19,11 @@ def ensure_connection():
 class RedisTestCase(BaseStorageTestCase, unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, storage_class=RedisDict, picklable=True, **kwargs)
+
+
+# @patch.object(Redis, '__init__', Redis.__init__)
+@patch('requests_cache.backends.redis.StrictRedis')
+def test_connection_kwargs(mock_redis):
+    """A spot check to make sure optional connection kwargs gets passed to connection"""
+    RedisCache('test', username='user', password='pass', invalid_kwarg='???')
+    mock_redis.assert_called_with(username='user', password='pass')

--- a/tests/integration/test_sqlite.py
+++ b/tests/integration/test_sqlite.py
@@ -89,7 +89,7 @@ class DbPickleDictTestCase(SQLiteTestCase, unittest.TestCase):
 
 
 @patch('requests_cache.backends.sqlite.sqlite3')
-def test_timeout(mock_sqlite):
-    """Just make sure the optional 'timeout' param gets passed to sqlite3.connect"""
-    DbDict('test', timeout=0.5)
+def test_connection_kwargs(mock_sqlite):
+    """A spot check to make sure optional connection kwargs gets passed to connection"""
+    DbDict('test', timeout=0.5, invalid_kwarg='???')
     mock_sqlite.connect.assert_called_with('test', timeout=0.5)


### PR DESCRIPTION
Closes #229, #194

* Pass `**kwargs` to backend storage classes, split out any that are valid for the backend-specific connection function/class, and pass them to the connection
* Add intersphinx links to docs for dependencies
* Update and format some more backend class docstrings
* Remove 'Unrecognized keyword arguments' warning from `BaseStorage`
* Turn `warnings.warn` about using secret keys into a `logging.warning` (due to complaints about too many messages)