### PR TITLE
Add some more convenience methods for getting cache info

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,9 @@
 * Add a filesystem backend that stores responses as local files
 * Add option to manually cache response objects
 * Add `use_temp` option to both SQLite and filesystem backends to store files in a temp directory
+* Add `BaseCache.keys()` and `values()` methods
+* Add response details to `CachedResponse.__str__()`
+* Update `BaseCache.urls` to only skip invalid responses, not delete them
 * Update `old_data_on_error` option to also handle error response codes
 * Use thread-local connections for SQLite backend
 * Fix `DynamoDbDict.__iter__` to return keys instead of values

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -27,8 +27,8 @@ Cache Inspection
 ----------------
 Here are some ways to get additional information out of the cache session, backend, and responses:
 
-Response Attributes
-~~~~~~~~~~~~~~~~~~~
+Response Details
+~~~~~~~~~~~~~~~~
 The following attributes are available on responses:
 * ``from_cache``: indicates if the response came from the cache
 * ``created_at``: :py:class:`~datetime.datetime` of when the cached response was created or last updated
@@ -41,18 +41,23 @@ Examples:
     >>> session = CachedSession(expire_after=timedelta(days=1))
 
     >>> # Placeholders are added for non-cached responses
-    >>> r = session.get('http://httpbin.org/get')
-    >>> print(r.from_cache, r.created_at, r.expires, r.is_expired)
+    >>> response = session.get('http://httpbin.org/get')
+    >>> print(response.from_cache, response.created_at, response.expires, response.is_expired)
     False None None None
 
     >>> # Values will be populated for cached responses
-    >>> r = session.get('http://httpbin.org/get')
-    >>> print(r.from_cache, r.created_at, r.expires, r.is_expired)
+    >>> response = session.get('http://httpbin.org/get')
+    >>> print(response.from_cache, response.created_at, response.expires, response.is_expired)
     True 2021-01-01 18:00:00 2021-01-02 18:00:00 False
+
+Alternatively, you can just print a response object to get general information about it:
+
+    >>> print(response)
+    'request: GET https://httpbin.org/get, response: 200 (308 bytes), created: 2021-01-01 22:45:00 IST, expires: 2021-01-02 18:45:00 IST (fresh)'
 
 Cache Contents
 ~~~~~~~~~~~~~~
-You can use :py:meth:`.CachedSession.cache.urls` to see all URLs currently in the cache:
+You can use ``CachedSession.cache.urls`` to see all URLs currently in the cache:
 
     >>> session = CachedSession()
     >>> print(session.cache.urls)
@@ -71,6 +76,16 @@ For example, if you wanted to to see all URLs requested with a specific method:
 
 You can also inspect ``CachedSession.cache.redirects``, which maps redirect URLs to keys of the
 responses they redirect to.
+
+Additional ``keys()`` and ``values()`` wrapper methods are available on :py:class:`.BaseCache` to get
+combined keys and responses.
+
+    >>> print('All responses:')
+    >>> for response in session.cache.values():
+    >>>     print(response)
+
+    >>> print('All cache keys for redirects and responses combined:')
+    >>> print(list(session.cache.keys()))
 
 Custom Backends
 ---------------
@@ -155,8 +170,8 @@ Example:
     >>>
     >>> session = CachedSession()
     >>> for i in range(2):
-    ...     r = session.get('https://httpbin.org/stream/20', stream=True)
-    ...     for chunk in r.iter_lines():
+    ...     response = session.get('https://httpbin.org/stream/20', stream=True)
+    ...     for chunk in response.iter_lines():
     ...         print(chunk.decode('utf-8'))
 
 
@@ -187,14 +202,14 @@ Example with `requests-html <https://github.com/psf/requests-html>`_:
     ...     """Session with features from both CachedSession and HTMLSession"""
     >>>
     >>> session = CachedHTMLSession()
-    >>> r = session.get('https://github.com/')
-    >>> print(r.from_cache, r.html.links)
+    >>> response = session.get('https://github.com/')
+    >>> print(response.from_cache, response.html.links)
 
 Or, using the monkey-patch method:
 
     >>> install_cache(session_factory=CachedHTMLSession)
-    >>> r = requests.get('https://github.com/')
-    >>> print(r.from_cache, r.html.links)
+    >>> response = requests.get('https://github.com/')
+    >>> print(response.from_cache, response.html.links)
 
 The same approach can be used with other libraries that subclass :py:class:`requests.Session`.
 

--- a/requests_cache/backends/mongo.py
+++ b/requests_cache/backends/mongo.py
@@ -13,7 +13,6 @@ class MongoCache(BaseCache):
     """
 
     def __init__(self, db_name: str = 'http_cache', connection: MongoClient = None, **kwargs):
-        """"""
         super().__init__(**kwargs)
         self.responses = MongoPickleDict(db_name, 'responses', connection=connection, **kwargs)
         self.redirects = MongoDict(

--- a/requests_cache/backends/sqlite.py
+++ b/requests_cache/backends/sqlite.py
@@ -27,7 +27,11 @@ class DbCache(BaseCache):
     """
 
     def __init__(
-        self, db_path: Union[Path, str] = 'http_cache', use_temp: bool = False, fast_save: bool = False, **kwargs
+        self,
+        db_path: Union[Path, str] = 'http_cache',
+        use_temp: bool = False,
+        fast_save: bool = False,
+        **kwargs,
     ):
         super().__init__(**kwargs)
         self.responses = DbPickleDict(db_path, table_name='responses', use_temp=use_temp, fast_save=fast_save, **kwargs)

--- a/requests_cache/response.py
+++ b/requests_cache/response.py
@@ -20,7 +20,9 @@ RAW_RESPONSE_ATTRS = [
     'strict',
     'version',
 ]
+CACHE_ATTRS = ['from_cache', 'created_at', 'expires', 'is_expired']
 
+DATETIME_SHORT_FORMAT = '%Y-%m-%d %H:%M'
 ExpirationTime = Union[None, int, float, datetime, timedelta]
 logger = getLogger(__name__)
 
@@ -119,6 +121,23 @@ class CachedResponse(Response):
         self.expires = self._get_expiration_datetime(expire_after)
         return self.is_expired
 
+    @property
+    def size(self) -> int:
+        """Get the size of the response body in bytes"""
+        return len(self.content) if self.content else 0
+
+    def __str__(self):
+        return (
+            f'request: {self.request.method} {self.request.url}, response: {self.status_code} '
+            f'({format_file_size(self.size)}), created: {format_datetime(self.created_at)}, '
+            f'expires: {format_datetime(self.expires)} ({"stale" if self.is_expired else "fresh"})'
+        )
+
+    def __repr__(self):
+        repr_attrs = set(RESPONSE_ATTRS + CACHE_ATTRS) - {'_content', 'elapsed'}
+        attr_strs = [f'{k}={getattr(self, k)}' for k in repr_attrs]
+        return f'<{self.__class__.__name__}({" ".join(attr_strs)})>'
+
 
 class CachedHTTPResponse(HTTPResponse):
     """A wrapper for raw urllib response objects, which wraps cached content with support for
@@ -158,6 +177,23 @@ class CachedHTTPResponse(HTTPResponse):
 
 
 AnyResponse = Union[Response, CachedResponse]
+
+
+def format_datetime(value: Optional[datetime]) -> str:
+    return value.strftime(DATETIME_SHORT_FORMAT) if value else "N/A"
+
+
+def format_file_size(n_bytes: int) -> str:
+    """Convert a file size in bytes into a human-readable format"""
+    filesize = float(n_bytes or 0)
+
+    def _format(unit):
+        return f'{int(filesize)} {unit}' if unit == 'bytes' else f'{filesize:.2f} {unit}'
+
+    for unit in ['bytes', 'KiB', 'MiB', 'GiB']:
+        if filesize < 1024 or unit == 'GiB':
+            return _format(unit)
+        filesize /= 1024
 
 
 def set_response_defaults(response: AnyResponse) -> AnyResponse:

--- a/requests_cache/response.py
+++ b/requests_cache/response.py
@@ -1,6 +1,6 @@
 """Classes to wrap cached response objects"""
 from copy import copy
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from io import BytesIO
 from logging import getLogger
 from typing import Any, Dict, Optional, Union
@@ -22,7 +22,7 @@ RAW_RESPONSE_ATTRS = [
 ]
 CACHE_ATTRS = ['from_cache', 'created_at', 'expires', 'is_expired']
 
-DATETIME_SHORT_FORMAT = '%Y-%m-%d %H:%M'
+DATETIME_FORMAT = '%Y-%m-%d %H:%M:%S %Z'
 ExpirationTime = Union[None, int, float, datetime, timedelta]
 logger = getLogger(__name__)
 
@@ -180,7 +180,12 @@ AnyResponse = Union[Response, CachedResponse]
 
 
 def format_datetime(value: Optional[datetime]) -> str:
-    return value.strftime(DATETIME_SHORT_FORMAT) if value else "N/A"
+    """Get a formatted datetime string in the local time zone"""
+    if not value:
+        return "N/A"
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone().strftime(DATETIME_FORMAT)
 
 
 def format_file_size(n_bytes: int) -> str:

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ extras_require = {
     ],
     # Packages used for testing both locally and in CI jobs
     'test': [
-        'black==20.8b1',
+        'black==21.4b0',
         'flake8',
         'flake8-comprehensions',
         'flake8-polyfill',


### PR DESCRIPTION
Closes #252 , #251

### New methods
* `BaseCache.keys()`: Get all response and redirect cache keys combined; ignores invalid responses
* `BaseCache.values()`: Get all response objects; ignores invalid responses
* `CachedSession.__str__()`: Get general info about the response and cache expiration
* `CachedSession.__repr__()`: Get a more verbose list of attributes
* `CachedSession.size`: Get human-readable size of response body (also included in `__str__`)

### Additional changes
* Update `BaseCache.urls` to return a generator instead of the whole list at once (which may use too much memory for particularly large caches)
* Update `BaseCache.urls` to just skip invalid responses instead of deleting them
* Update changelog and user guide