### PR TITLE
 Improve performance for remove_expired_responses(), mainly for SQLite backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
+*.db
 *.py[cod]
 *.sqlite
+*.sqlite-journal
 *.egg
 *.egg-info
 build/

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,6 +9,7 @@
 * Update `BaseCache.urls` to only skip invalid responses, not delete them
 * Update `old_data_on_error` option to also handle error response codes
 * Use thread-local connections for SQLite backend
+* Improve performance for `remove_expired_responses()`, mainly for SQLite backend
 * Fix `DynamoDbDict.__iter__` to return keys instead of values
 
 ### 0.6.3 (2021-04-21)

--- a/examples/generate_test_db.py
+++ b/examples/generate_test_db.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+"""An example of generating a test database with a large number of semi-randomized responses.
+This is useful, for example, for reproducing issues that only occur with large caches.
+"""
+import logging
+from os import urandom
+from os.path import getsize
+from random import random
+from time import perf_counter as time
+
+from rich.progress import Progress
+
+from requests_cache import ALL_METHODS, CachedSession, CachedResponse
+from requests_cache.response import format_file_size
+from tests.conftest import HTTPBIN_FORMATS, HTTPBIN_METHODS, httpbin
+
+
+CACHE_NAME = 'rubbish_bin.sqlite'
+HTTPBIN_EXTRA_ENDPOINTS = [
+    'anything',
+    'bytes/1024' 'cookies',
+    'ip',
+    'redirect/5',
+    'stream-bytes/1024',
+]
+MAX_EXPIRE_AFTER = 30
+MAX_RESPONSE_SIZE = 10000
+N_RESPONSES = 100000
+N_INVALID_RESPONSES = 10
+
+logging.basicConfig(level='INFO')
+logger = logging.getLogger('requests_cache')
+
+
+class InvalidResponse(CachedResponse):
+    """Response that will raise an exception when deserialized"""
+
+    def __setstate__(self, d):
+        raise ValueError
+
+
+def populate_cache(progress, task):
+    session = CachedSession(CACHE_NAME, backend='sqlite', allowable_methods=ALL_METHODS)
+
+    # Cache a variety of different response formats, which may result in different behavior
+    urls = [('GET', httpbin(endpoint)) for endpoint in HTTPBIN_FORMATS + HTTPBIN_EXTRA_ENDPOINTS]
+    urls += [(method, httpbin(method.lower())) for method in HTTPBIN_METHODS]
+    for method, url in urls:
+        session.request(method, url)
+        progress.update(task, advance=1)
+
+    # Cache a large number of responses with randomized response content, which will expire at random times
+    response = session.get(httpbin('get'))
+    with session.cache.responses.bulk_commit():
+        for i in range(N_RESPONSES):
+            new_response = CachedResponse(response)
+            n_bytes = int(random() * MAX_RESPONSE_SIZE)
+            new_response._content = urandom(n_bytes)
+
+            new_response.request.url += f'/response_{i}'
+            expire_after = random() * MAX_EXPIRE_AFTER
+            key = session.cache.create_key(new_response.request)
+            session.cache.save_response(key, new_response, expire_after=expire_after)
+            progress.update(task, advance=1)
+
+    # Add some invalid responses
+    with session.cache.responses.bulk_commit():
+        for i in range(N_INVALID_RESPONSES):
+            new_response = InvalidResponse(response)
+            new_response.request.url += f'/invalid_response_{i}'
+            key = session.cache.create_key(new_response.request)
+            session.cache.responses[key] = new_response
+            progress.update(task, advance=1)
+
+
+def remove_expired_responses(expire_after=None):
+    logger.setLevel('DEBUG')
+    session = CachedSession(CACHE_NAME)
+    total_responses = len(session.cache.responses)
+
+    start = time()
+    session.remove_expired_responses(expire_after=expire_after)
+    elapsed = time() - start
+    n_removed = total_responses - len(session.cache.responses)
+    logger.info(
+        f'Removed {n_removed} expired/invalid responses in {elapsed:.2f} seconds '
+        f'(avg {(elapsed / n_removed) * 1000:.2f}ms per response)'
+    )
+
+
+def main():
+    total_responses = len(HTTPBIN_FORMATS + HTTPBIN_EXTRA_ENDPOINTS + HTTPBIN_METHODS)
+    total_responses += N_RESPONSES + N_INVALID_RESPONSES
+
+    with Progress() as progress:
+        task = progress.add_task('[cyan]Generating responses...', total=total_responses)
+        populate_cache(progress, task)
+
+    actual_total_responses = len(CachedSession(CACHE_NAME).cache.responses)
+    cache_file_size = format_file_size(getsize(CACHE_NAME))
+    logger.info(f'Generated cache with {actual_total_responses} responses ({cache_file_size})')
+
+
+if __name__ == '__main__':
+    main()
+
+    # Remove some responses (with randomized expiration)
+    # remove_expired_responses()
+
+    # Expire and remove all responses
+    # remove_expired_responses(expire_after=1)

--- a/requests_cache/response.py
+++ b/requests_cache/response.py
@@ -85,7 +85,6 @@ class CachedResponse(Response):
 
     def _get_expiration_datetime(self, expire_after: ExpirationTime) -> Optional[datetime]:
         """Convert a time value or delta to an absolute datetime, if it's not already"""
-        logger.debug(f'Determining expiration time based on: {expire_after}')
         if expire_after is None or expire_after == -1:
             return None
         elif isinstance(expire_after, datetime):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,6 +131,13 @@ def tempfile_session() -> CachedSession:
 
 
 @pytest.fixture(scope='function')
+def tempfile_path() -> CachedSession:
+    """Get a tempfile path that will be deleted after the test finished"""
+    with NamedTemporaryFile(suffix='.db') as temp:
+        yield temp.name
+
+
+@pytest.fixture(scope='function')
 def installed_session() -> CachedSession:
     """Get a CachedSession using a temporary SQLite db, with global patching.
     Installs cache before test and uninstalls after.

--- a/tests/integration/base_cache_test.py
+++ b/tests/integration/base_cache_test.py
@@ -2,7 +2,7 @@
 import json
 import pytest
 from threading import Thread
-from time import time
+from time import sleep, time
 from typing import Dict, Type
 
 from requests_cache import ALL_METHODS, CachedResponse, CachedSession
@@ -64,7 +64,7 @@ class BaseCacheTest:
     def test_redirects(self, endpoint, n_redirects):
         """Test all types of redirect endpoints with different numbers of consecutive redirects"""
         session = self.init_session()
-        session.get(httpbin(f'redirect/{n_redirects}'))
+        session.get(httpbin(f'{endpoint}/{n_redirects}'))
         r2 = session.get(httpbin('get'))
 
         assert r2.from_cache is True
@@ -106,6 +106,25 @@ class BaseCacheTest:
         for res in (response_uncached, response_cached):
             assert b'gzipped' in res.content
             assert b'gzipped' in res.raw.read(None, decode_content=True)
+
+    def test_remove_expired_responses(self):
+        session = self.init_session(expire_after=0.01)
+
+        # Populate the cache with several responses that should expire immediately
+        for response_format in HTTPBIN_FORMATS:
+            session.get(httpbin(response_format))
+        session.get(httpbin('redirect/1'))
+        sleep(0.01)
+
+        # Cache a response + redirects, which should be the only non-expired cache items
+        session.get(httpbin('get'), expire_after=-1)
+        session.get(httpbin('redirect/3'), expire_after=-1)
+        session.cache.remove_expired_responses()
+
+        assert len(session.cache.responses.keys()) == 2
+        assert len(session.cache.redirects.keys()) == 3
+        assert not session.cache.has_url(httpbin('redirect/1'))
+        assert not any([session.cache.has_url(httpbin(f)) for f in HTTPBIN_FORMATS])
 
     @pytest.mark.parametrize('iteration', range(N_ITERATIONS))
     def test_multithreaded(self, iteration):

--- a/tests/integration/test_sqlite.py
+++ b/tests/integration/test_sqlite.py
@@ -14,7 +14,7 @@ class SQLiteTestCase(BaseStorageTest):
     @classmethod
     def teardown_class(cls):
         try:
-            os.unlink(CACHE_NAME)
+            os.unlink(f'{CACHE_NAME}.sqlite')
         except Exception:
             pass
 
@@ -79,7 +79,7 @@ class SQLiteTestCase(BaseStorageTest):
     @patch('requests_cache.backends.sqlite.sqlite3')
     def test_connection_kwargs(self, mock_sqlite):
         """A spot check to make sure optional connection kwargs gets passed to connection"""
-        cache = self.storage_class('test', timeout=0.5, invalid_kwarg='???')
+        cache = self.storage_class('test', use_temp=True, timeout=0.5, invalid_kwarg='???')
         mock_sqlite.connect.assert_called_with(cache.db_path, timeout=0.5)
 
 

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -330,7 +330,7 @@ def test_response_defaults(mock_session):
     assert response_2.is_expired is response_3.is_expired is False
 
 
-def testinclude_get_headers(mock_session):
+def test_include_get_headers(mock_session):
     """With include_get_headers, requests with different headers should have different cache keys"""
     mock_session.cache.include_get_headers = True
     headers_list = [{'Accept': 'text/json'}, {'Accept': 'text/xml'}, {'Accept': 'custom'}, None]
@@ -339,7 +339,7 @@ def testinclude_get_headers(mock_session):
         assert mock_session.get(MOCKED_URL, headers=headers).from_cache is True
 
 
-def testinclude_get_headers_normalize(mock_session):
+def test_include_get_headers_normalize(mock_session):
     """With include_get_headers, the same headers (in any order) should have the same cache key"""
     mock_session.cache.include_get_headers = True
     headers = {'Accept': 'text/json', 'Custom': 'abc'}


### PR DESCRIPTION
Follow-up from #240 and #253

### Main changes
* Some minor performance improvements for `remove_expired_responses()` that apply to all backends
* Some additional SQLite-specific improvements
* TODO (in future PRs): Similar bulk delete improvements for the rest of the backends
* Note that `remove_expired_responses()` is still fairly inefficient, in that it deserializes responses to get the expiration time. Optimizing it will require adding an indexed expiration column (and possibly other breaking changes).

### Other changes
* Add an example script to generate a large cache for testing purposes
* Make sure all tests with SQLite dbs clean up after themselves (a few remaining tests weren't yet doing this)
* Remove a couple less useful logging statements