### PR TITLE
Implement a faster bulk delete method for each backend

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,7 +12,7 @@
 * Update `BaseCache.urls` to only skip invalid responses, not delete them
 * Update `old_data_on_error` option to also handle error response codes
 * Use thread-local connections for SQLite backend
-* Improve performance for `remove_expired_responses()`, mainly for SQLite backend
+* Improve performance for `remove_expired_responses()`
 * Fix `DynamoDbDict.__iter__` to return keys instead of values
 
 ### 0.6.3 (2021-04-21)

--- a/requests_cache/backends/redis.py
+++ b/requests_cache/backends/redis.py
@@ -1,3 +1,5 @@
+from typing import Iterable
+
 from redis import Redis, StrictRedis
 
 from . import BaseCache, BaseStorage, get_valid_kwargs
@@ -57,6 +59,11 @@ class RedisDict(BaseStorage):
     def __iter__(self):
         for v in self.connection.hkeys(self._self_key):
             yield self.deserialize(v)
+
+    def bulk_delete(self, keys: Iterable[str]):
+        """Delete multiple keys from the cache. Does not raise errors for missing keys."""
+        if keys:
+            self.connection.hdel(self._self_key, *[self.serialize(key) for key in keys])
 
     def clear(self):
         self.connection.delete(self._self_key)

--- a/tests/integration/base_storage_test.py
+++ b/tests/integration/base_storage_test.py
@@ -72,6 +72,16 @@ class BaseStorageTest:
         assert set(cache.keys()) == {f'key_{i}' for i in range(5, 20)}
         assert set(cache.values()) == {f'value_{i}' for i in range(5, 20)}
 
+    def test_bulk_delete(self):
+        cache = self.init_cache()
+        for i in range(20):
+            cache[f'key_{i}'] = f'value_{i}'
+        cache.bulk_delete([f'key_{i}' for i in range(5)])
+
+        assert len(cache) == 15
+        assert set(cache.keys()) == {f'key_{i}' for i in range(5, 20)}
+        assert set(cache.values()) == {f'value_{i}' for i in range(5, 20)}
+
     def test_keyerrors(self):
         """Accessing or deleting a deleted item should raise a KeyError"""
         cache = self.init_cache()


### PR DESCRIPTION
Closes #257

### Other changes
* Instead of checking each deleted response for redirects to delete, just delete redirects that point to a non-existing response. In most cases this results in much fewer calls.
* Remove usage of deprecated pymongo `Collection.find_and_modify()`