### PR TITLE
Remove spurious logger.exception()

### DIFF
--- a/requests_cache/session.py
+++ b/requests_cache/session.py
@@ -152,7 +152,6 @@ class CacheMixin:
             return new_response
         # Return the expired/invalid response on error, if specified; otherwise reraise
         except Exception as e:
-            logger.exception(e)
             if self.old_data_on_error:
                 logger.warning('Request failed; using stale cache data')
                 return response

--- a/requests_cache/session.py
+++ b/requests_cache/session.py
@@ -153,7 +153,7 @@ class CacheMixin:
         # Return the expired/invalid response on error, if specified; otherwise reraise
         except Exception as e:
             if self.old_data_on_error:
-                logger.warning('Request failed; using stale cache data')
+                logger.warning('Request failed; using stale cache data: %s', e)
                 return response
             self.cache.delete(cache_key)
             raise


### PR DESCRIPTION
The exception is re-raised, so logging an incomplete traceback at this point makes little sense to me.  Either the caller will catch the exception and log it, or the caller wants the exception suppressed, in which case the incomplete traceback logged here will just confuse them (example: https://github.com/mgedmin/project-summary/issues/3#issuecomment-833257387).

Perhaps logging the original error is useful when `old_data_on_error` is True, in which case I could pass `exc_info=True` to the `logger.warning()` invocation inside the if statement?