### PR TITLE
Remove data in "ignored_parameters" from cached requests

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -178,6 +178,10 @@ or credentials. If you want to ignore specific parameters, specify them with ``i
     >>> session.get('http://httpbin.org/get', params={'auth-token': '2F63E5DF4F44'})
     >>> session.get('http://httpbin.org/get', params={'auth-token': 'D9FAEB3449D3'})
 
+In addition to allowing the cache to ignore these parameters when fetching cached results, these
+parameters will also be removed from the cache data. This makes ``ignored_parameters`` a good way to
+prevent key material or other secrets from being saved in the cache backend.
+
 Request Headers
 ~~~~~~~~~~~~~~~
 In some cases, different headers may result in different response data, so you may want to cache
@@ -208,7 +212,7 @@ request, the following order of precedence is used:
 3. Per-request expiration (``expire_after`` argument for :py:meth:`.CachedSession.request`)
 4. Per-URL expiration (``urls_expire_after`` argument for :py:class:`.CachedSession`)
 5. Per-session expiration (``expire_after`` argument for :py:class:`.CacheBackend`)
-    
+
 Expiration Values
 ~~~~~~~~~~~~~~~~~
 ``expire_after`` can be any of the following:
@@ -268,14 +272,14 @@ Cache-Control
 .. warning::
     This is **not** intended to be a thorough or strict implementation of header-based HTTP caching,
     e.g. according to RFC 2616.
-                                                                                                     
+
 Optional support is included for a simplified subset of
 `Cache-Control <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control>`_
 and other cache headers in both requests and responses. To enable this behavior, use the
 ``cache_control`` option:
-                                                                                                     
-    >>> session = CachedSession(cache_control=True)                                                    
-                                                                                                     
+
+    >>> session = CachedSession(cache_control=True)
+
 **Supported request headers:**
 
 * ``Cache-Control: max-age``: Used as the expiration time in seconds
@@ -290,10 +294,10 @@ and other cache headers in both requests and responses. To enable this behavior,
 
 **Notes:**
 
-* Unlike a browser or proxy cache, ``max-age=0`` does not currently clear previously cached responses.              
+* Unlike a browser or proxy cache, ``max-age=0`` does not currently clear previously cached responses.
 * If enabled, Cache-Control directives will take priority over any other ``expire_after`` value.
   See :ref:`user_guide:expiration precedence` for the full order of precedence.
-  
+
 Removing Expired Responses
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 For better performance, expired responses won't be removed immediately, but will be removed

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -179,8 +179,9 @@ or credentials. If you want to ignore specific parameters, specify them with ``i
     >>> session.get('http://httpbin.org/get', params={'auth-token': 'D9FAEB3449D3'})
 
 In addition to allowing the cache to ignore these parameters when fetching cached results, these
-parameters will also be removed from the cache data. This makes ``ignored_parameters`` a good way to
-prevent key material or other secrets from being saved in the cache backend.
+parameters will also be removed from the cache data, including in the request headers.
+This makes ``ignored_parameters`` a good way to prevent key material or other secrets from being
+saved in the cache backend.
 
 Request Headers
 ~~~~~~~~~~~~~~~

--- a/poetry.lock
+++ b/poetry.lock
@@ -164,6 +164,17 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "commonmark"
+version = "0.9.1"
+description = "Python parser for the CommonMark Markdown spec"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.extras]
+test = ["flake8 (==3.7.8)", "hypothesis (==3.55.3)"]
+
+[[package]]
 name = "coverage"
 version = "5.5"
 description = "Code coverage measurement for Python"
@@ -378,6 +389,22 @@ optional = true
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "jsonpickle"
+version = "2.0.0"
+description = "Python library for serializing any arbitrary object graph into JSON"
+category = "dev"
+optional = false
+python-versions = ">=2.7"
+
+[package.dependencies]
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
+testing = ["coverage (<5)", "pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-black-multipy", "pytest-cov", "ecdsa", "feedparser", "numpy", "pandas", "pymongo", "sklearn", "sqlalchemy", "enum34", "jsonlib"]
+"testing.libs" = ["demjson", "simplejson", "ujson", "yajl"]
+
+[[package]]
 name = "m2r2"
 version = "0.2.7"
 description = "Markdown and reStructuredText in a single file."
@@ -418,6 +445,17 @@ description = "McCabe checker, plugin for flake8"
 category = "dev"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "memory-profiler"
+version = "0.58.0"
+description = "A module for monitoring memory usage of a python program"
+category = "dev"
+optional = false
+python-versions = ">=3.4"
+
+[package.dependencies]
+psutil = "*"
 
 [[package]]
 name = "mistune"
@@ -542,7 +580,7 @@ name = "pygments"
 version = "2.9.0"
 description = "Pygments is a syntax highlighting package written in Python."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.5"
 
 [[package]]
@@ -741,6 +779,24 @@ six = "*"
 [package.extras]
 fixture = ["fixtures"]
 test = ["fixtures", "mock", "purl", "pytest", "sphinx", "testrepository (>=0.0.18)", "testtools"]
+
+[[package]]
+name = "rich"
+version = "10.2.2"
+description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
+category = "dev"
+optional = false
+python-versions = ">=3.6,<4.0"
+
+[package.dependencies]
+colorama = ">=0.4.0,<0.5.0"
+commonmark = ">=0.9.0,<0.10.0"
+dataclasses = {version = ">=0.7,<0.9", markers = "python_version >= \"3.6\" and python_version < \"3.7\""}
+pygments = ">=2.6.0,<3.0.0"
+typing-extensions = {version = ">=3.7.4,<4.0.0", markers = "python_version < \"3.8\""}
+
+[package.extras]
+jupyter = ["ipywidgets (>=7.5.1,<8.0.0)"]
 
 [[package]]
 name = "s3transfer"
@@ -1026,7 +1082,7 @@ json = ["cattrs"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "eb49f99d8cf801e7f83ad019bb44f4d452adf036fa28abfa12c5d19f131f30db"
+content-hash = "128aea55c1075aae6d0e2f231962f066ddf1a59360e3c7445fb2bfc04ca72b36"
 
 [metadata.files]
 alabaster = [
@@ -1088,6 +1144,10 @@ click = [
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
+]
+commonmark = [
+    {file = "commonmark-0.9.1-py2.py3-none-any.whl", hash = "sha256:da2f38c92590f83de410ba1a3cbceafbc74fee9def35f9251ba9a971d6d66fd9"},
+    {file = "commonmark-0.9.1.tar.gz", hash = "sha256:452f9dc859be7f06631ddcb328b6919c67984aca654e5fefb3914d54691aed60"},
 ]
 coverage = [
     {file = "coverage-5.5-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:b6d534e4b2ab35c9f93f46229363e17f63c53ad01330df9f2d6bd1187e5eaacf"},
@@ -1218,6 +1278,10 @@ jmespath = [
     {file = "jmespath-0.10.0-py2.py3-none-any.whl", hash = "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"},
     {file = "jmespath-0.10.0.tar.gz", hash = "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9"},
 ]
+jsonpickle = [
+    {file = "jsonpickle-2.0.0-py2.py3-none-any.whl", hash = "sha256:c1010994c1fbda87a48f8a56698605b598cb0fc6bb7e7927559fc1100e69aeac"},
+    {file = "jsonpickle-2.0.0.tar.gz", hash = "sha256:0be49cba80ea6f87a168aa8168d717d00c6ca07ba83df3cec32d3b30bfe6fb9a"},
+]
 m2r2 = [
     {file = "m2r2-0.2.7-py3-none-any.whl", hash = "sha256:a1b87b00f4d5163a3616253fca4c045f8351818cd803ba2e24af8897442a0eae"},
     {file = "m2r2-0.2.7.tar.gz", hash = "sha256:fbf72ade9f648d41658f97c5267687431612451f36b65761a138fbc276294df5"},
@@ -1265,6 +1329,9 @@ markupsafe = [
 mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
+]
+memory-profiler = [
+    {file = "memory_profiler-0.58.0.tar.gz", hash = "sha256:01385ac0fec944fcf7969814ec4406c6d8a9c66c079d09276723c5a7680f44e5"},
 ]
 mistune = [
     {file = "mistune-0.8.4-py2.py3-none-any.whl", hash = "sha256:88a1051873018da288eee8538d476dffe1262495144b33ecb586c4ab266bb8d4"},
@@ -1531,6 +1598,10 @@ requests = [
 requests-mock = [
     {file = "requests-mock-1.9.2.tar.gz", hash = "sha256:33296f228d8c5df11a7988b741325422480baddfdf5dd9318fd0eb40c3ed8595"},
     {file = "requests_mock-1.9.2-py2.py3-none-any.whl", hash = "sha256:5c8ef0254c14a84744be146e9799dc13ebc4f6186058112d9aeed96b131b58e2"},
+]
+rich = [
+    {file = "rich-10.2.2-py3-none-any.whl", hash = "sha256:203e79c9012f57e0148a2132d0b43fe070a5c213cf080982c186e1d3ae4f8e1d"},
+    {file = "rich-10.2.2.tar.gz", hash = "sha256:17b3f486c38e79cc219d8848974b277ef532a82d12b3ad6eb37bb8c6f22ab5fc"},
 ]
 s3transfer = [
     {file = "s3transfer-0.4.2-py2.py3-none-any.whl", hash = "sha256:9b3752887a2880690ce628bc263d6d13a3864083aeacff4890c1c9839a5eb0bc"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,9 @@ pytest-xdist = "^2.2"
 radon = "^4.5"
 requests-mock = "^1.8"
 timeout-decorator = "^0.5"
+jsonpickle = "^2.0"
+rich = "^10.2"
+memory-profiler = "^0.58"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/requests_cache/backends/base.py
+++ b/requests_cache/backends/base.py
@@ -32,9 +32,6 @@ class BaseCache:
         *args,
         include_get_headers: bool = False,
         ignored_parameters: Iterable[str] = None,
-        # filter_headers: Iterable[str] = list(),
-        # filter_query_parameters: Iterable[str] = list(),
-        # filter_post_data_parameters: Iterable[str] = list(),
         **kwargs,
     ):
         self.name = None
@@ -42,9 +39,6 @@ class BaseCache:
         self.responses = {}
         self.include_get_headers = include_get_headers
         self.ignored_parameters = ignored_parameters
-        # self.filter_headers = filter_headers
-        # self.filter_query_parameters = filter_query_parameters
-        # self.filter_post_data_parameters = filter_post_data_parameters
 
     @property
     def urls(self) -> Iterator[str]:

--- a/requests_cache/cache_keys.py
+++ b/requests_cache/cache_keys.py
@@ -35,6 +35,25 @@ def create_key(
     return key.hexdigest()
 
 
+def remove_ignored_params(
+    request: requests.PreparedRequest, ignored_params: Iterable[str]
+) -> requests.PreparedRequest:
+    if not ignored_params:
+        return request
+    request.headers = remove_ignored_headers(request, ignored_params)
+    request.url = remove_ignored_url_params(request, ignored_params)
+    request.body = remove_ignored_body_params(request, ignored_params)
+    return request
+
+
+def remove_ignored_headers(request: requests.PreparedRequest, ignored_params: Iterable[str]) -> dict:
+    if not ignored_params:
+        return request.headers
+    headers = request.headers.copy()
+    headers.update({k: None for k in ignored_params})
+    return headers
+
+
 def remove_ignored_url_params(request: requests.PreparedRequest, ignored_params: Iterable[str]) -> str:
     url = str(request.url)
     if not ignored_params:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -225,6 +225,10 @@ def fail_if_no_connection(func) -> bool:
         try:
             timeout(1.0)(func)(*args, **kwargs)
         except Exception as e:
+            # timeout_decorator is not Windows compatible, because it relies on process signals that
+            # don't exist in windows. This is an escape valve for that specific error.
+            if isinstance(e, AttributeError) and str(e) == "module 'signal' has no attribute 'SIGALRM'":
+                return
             logger.error(e)
             pytest.fail('Could not connect to backend')
 

--- a/tests/integration/base_cache_test.py
+++ b/tests/integration/base_cache_test.py
@@ -192,19 +192,19 @@ class BaseCacheTest:
             ]
         )
         response = session.request(method, url, headers={"Authorization": "<Secret Key>"})
-        assert response.from_cache == False
+        assert response.from_cache is False
         response = session.request(method, url, headers={"Authorization": "<Secret Key>"})
-        assert response.from_cache == True
-        assert response.request.headers['Authorization'] == None
+        assert response.from_cache is True
+        assert response.request.headers['Authorization'] is None
 
     @pytest.mark.parametrize('method', HTTPBIN_METHODS)
     def test_filter_request_query_parameters(self, method):
         url = httpbin(method.lower())
         session = self.init_session(ignored_parameters=['api_key'])
         response = session.request(method, url, params={"api_key": "<Secret Key>"})
-        assert response.from_cache == False
+        assert response.from_cache is False
         response = session.request(method, url, params={"api_key": "<Secret Key>"})
-        assert response.from_cache == True
+        assert response.from_cache is True
         query = urlparse(response.request.url).query
         query_dict = parse_qs(query)
         assert 'api_key' not in query_dict
@@ -215,9 +215,9 @@ class BaseCacheTest:
         url = httpbin(method.lower())
         session = self.init_session(ignored_parameters=['api_key'])
         response = session.request(method, url, **{post_type: {"api_key": "<Secret Key>"}})
-        assert response.from_cache == False
+        assert response.from_cache is False
         response = session.request(method, url, **{post_type: {"api_key": "<Secret Key>"}})
-        assert response.from_cache == True
+        assert response.from_cache is True
         if post_type == 'data':
             body = parse_qs(response.request.body)
             assert "api_key" not in body

--- a/tests/performance_test.py
+++ b/tests/performance_test.py
@@ -18,7 +18,7 @@ import jsonpickle
 from memory_profiler import profile
 from rich import print
 
-from requests_cache import *
+from requests_cache import CachedSession
 from requests_cache.serializers import PickleSerializer
 
 ITERATIONS = 10000


### PR DESCRIPTION
This is an initial implementation of #273 

The library already has functionality for stripping "ignored_parameters" out of a `PreparedRequest` so that those parameters link to the same cached response. As an initial and minimal way of accomplishing #273, essentially the same code used for "ignored_parameters" is also used to strip that information out of a CachedResponse prior to being sent to a backend.

This pull request also includes minor updates necessary to get the tests to pass on a fresh install.
