### PR TITLE
validate requests.PreparedRequest.method type hint

### DIFF
--- a/requests_cache/cache_keys.py
+++ b/requests_cache/cache_keys.py
@@ -18,6 +18,11 @@ def create_key(
     **kwargs,
 ) -> str:
     """Create a normalized cache key from a request object"""
+    if request.method is None:
+        # Question: Is method required to be set? probably yes
+        #  if so should raise an error on requests.PreparedRequest.prepare_method
+        #  Or maybe it should be required on init
+        raise TypeError('Incorrectly Configured: requests.PreparedRequest.method must be of type str')
     key = hashlib.sha256()
     key.update(_encode(request.method.upper()))
     url = remove_ignored_url_params(request, ignored_params)


### PR DESCRIPTION
Just getting the conversation going, this is not the solution.
```
requests_cache/cache_keys.py:27: error: Item "None" of "Optional[str]" has no attribute "upper"
```

My assumptions are that request.method (`requests.PreparedRequest.method`) type must be a String at this point in code.

Bad simple solution would be to accept my pr

Decent solution would be to raise an error in the `requests.PreparedRequest.prepare_method` if method is not provided and add a return type hint

If it's always required, my preference would be to have it as required and do `prepare` on init, but that's more work and depending on test setup, not worth it.

