### PR TITLE
Add some more options for excluding invalid and expired responses in cache counts

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -39,6 +39,7 @@
 ### General
 * Add option to manually cache response objects with `BaseCache.save_response()`
 * Add `BaseCache.keys()` and `values()` methods
+* Add `BaseCache.response_count()` method to get an accurate count of responses (excluding invalid and expired)
 * Show summarized response details with `str(CachedResponse)`
 * Add more detailed repr methods for `CachedSession`, `CachedResponse`, and `BaseCache`
 * Add support for caching multipart form uploads
@@ -112,7 +113,7 @@ next time they are requested. They can also be manually converted or removed, if
 * Add [example script](https://github.com/reclosedev/requests-cache/blob/master/examples/convert_cache.py)
   to convert an existing cache from previous serialization format to new one
 * When running `remove_expired_responses()`, also remove responses that are invalid due to updated
-  serialization format 
+  serialization format
 * Add `CachedResponse` class to wrap cached `requests.Response` objects, which makes additional
   cache information available to client code
 * Add `CachedHTTPResponse` class to wrap `urllib3.response.HTTPResponse` objects, available via `CachedResponse.raw`

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -72,6 +72,18 @@ combined keys and responses.
     >>> print('All cache keys for redirects and responses combined:')
     >>> print(list(session.cache.keys()))
 
+Both methods also take a ``check_expiry`` argument to exclude expired responses:
+
+    >>> print('All unexpired responses:')
+    >>> for response in session.cache.values(check_expiry=True):
+    >>>     print(response)
+
+Similarly, you can get a count of responses with :py:meth:`.BaseCache.response_count`, and optionally
+exclude expired responses:
+
+    >>> print(f'Total responses: {session.cache.response_count()}')
+    >>> print(f'Unexpired responses: {session.cache.response_count(check_expiry=True)}')
+
 Custom Response Filtering
 -------------------------
 If you need more advanced behavior for determining what to cache, you can provide a custom filtering

--- a/requests_cache/backends/base.py
+++ b/requests_cache/backends/base.py
@@ -202,7 +202,10 @@ class BaseCache:
             self.bulk_delete(keys_to_delete)
 
     def __str__(self):
-        return f'redirects: {len(self.redirects)}\nresponses: {len(self.responses)}'
+        """Show a count of total rows. For performance reasons, this does not check for invalid or
+        expired responses.
+        """
+        return f'Total rows: {len(self.responses)} responses, {len(self.redirects)} redirects'
 
     def __repr__(self):
         return f'<{self.__class__.__name__}(name={self.name})>'

--- a/requests_cache/backends/base.py
+++ b/requests_cache/backends/base.py
@@ -179,6 +179,12 @@ class BaseCache:
         for _, response in self._get_valid_responses():
             yield response
 
+    def response_count(self, check_expiry=False) -> int:
+        """Get the number of valid responses in the cache, excluding invalid (unusable) responses.
+        Can also optionally exclude expired responses.
+        """
+        return len(list(self._get_valid_responses(check_expiry=check_expiry)))
+
     def _get_valid_responses(self, delete_invalid=False) -> Iterator[Tuple[str, CachedResponse]]:
         """Get all responses from the cache, and skip (+ optionally delete) any invalid ones that
         can't be deserialized"""

--- a/requests_cache/models/response.py
+++ b/requests_cache/models/response.py
@@ -107,11 +107,6 @@ class CachedResponse(Response):
         """Get the size of the response body in bytes"""
         return len(self.content) if self.content else 0
 
-    # TODO: Behavior will be different for slotted classes
-    # def __getstate__(self):
-    #     """Override pickling behavior in ``requests.Response.__getstate__``"""
-    #     return self.__dict__
-
     def __str__(self):
         return (
             f'request: {self.request}, response: {self.status_code} '

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -187,6 +187,25 @@ def test_values__with_invalid_response(mock_session):
     assert len(mock_session.cache.responses.keys()) == 3
 
 
+class TimeBomb:
+    """Class that will raise an error when unpickled"""
+
+    def __init__(self):
+        self.foo = 'bar'
+
+    def __setstate__(self, value):
+        raise ValueError('Invalid response!')
+
+
+def test_valid_response_count(mock_session):
+    """valid_response_count() should count only valid and unexpired responses"""
+    mock_session.get(MOCKED_URL)
+    mock_session.get(MOCKED_URL_JSON)
+
+    mock_session.cache.responses['invalid_response'] = TimeBomb()
+    assert mock_session.cache.valid_response_count() == 2
+
+
 def test_filter_fn(mock_session):
     mock_session.filter_fn = lambda r: r.request.url != MOCKED_URL_JSON
     mock_session.get(MOCKED_URL)

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -35,6 +35,8 @@ from tests.conftest import (
     MOCKED_URL_REDIRECT_TARGET,
 )
 
+YESTERDAY = datetime.utcnow() - timedelta(days=1)
+
 
 def test_init_unregistered_backend():
     with pytest.raises(ValueError):
@@ -177,11 +179,16 @@ def test_values(mock_session):
     assert all([isinstance(response, CachedResponse) for response in responses])
 
 
-def test_values__with_invalid_response(mock_session):
+@pytest.mark.parametrize('check_expiry, expected_count', [(True, 1), (False, 2)])
+def test_values__with_invalid_responses(check_expiry, expected_count, mock_session):
+    """values() should always exclude invalid responses, and optionally exclude expired responses"""
     responses = [mock_session.get(url) for url in [MOCKED_URL, MOCKED_URL_JSON, MOCKED_URL_HTTPS]]
-    responses[2] = AttributeError
+    responses[1] = AttributeError
+    responses[2] = CachedResponse(expires=YESTERDAY, url='test')
+
     with patch.object(DbPickleDict, '__getitem__', side_effect=responses):
-        assert len(list(mock_session.cache.values())) == 2
+        values = mock_session.cache.values(check_expiry=check_expiry)
+        assert len(list(values)) == expected_count
 
     # The invalid response should be skipped, but remain in the cache for now
     assert len(mock_session.cache.responses.keys()) == 3
@@ -197,13 +204,15 @@ class TimeBomb:
         raise ValueError('Invalid response!')
 
 
-def test_valid_response_count(mock_session):
-    """valid_response_count() should count only valid and unexpired responses"""
+@pytest.mark.parametrize('check_expiry, expected_count', [(True, 2), (False, 3)])
+def test_response_count(check_expiry, expected_count, mock_session):
+    """response_count() should always exclude invalid responses, and optionally exclude expired responses"""
     mock_session.get(MOCKED_URL)
     mock_session.get(MOCKED_URL_JSON)
 
+    mock_session.cache.responses['expired_response'] = CachedResponse(expires=YESTERDAY)
     mock_session.cache.responses['invalid_response'] = TimeBomb()
-    assert mock_session.cache.valid_response_count() == 2
+    assert mock_session.cache.response_count(check_expiry=check_expiry) == expected_count
 
 
 def test_filter_fn(mock_session):

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -138,7 +138,7 @@ def test_repr(mock_session):
     mock_session.cache.redirects['key_2'] = 'value'
 
     assert mock_session.cache.name in repr(mock_session) and '10.5' in repr(mock_session)
-    assert 'redirects: 2' in str(mock_session.cache) and 'responses: 1' in str(mock_session.cache)
+    assert '2 redirects' in str(mock_session.cache) and '1 responses' in str(mock_session.cache)
 
 
 def test_urls(mock_session):


### PR DESCRIPTION
Updates #296

* Add `BaseCache.response_count()` method to get an accurate count of responses (excluding invalid/broken ones)
* Add option to also exclude expired responses in `BaseCache.keys()`, `values()`, and `response_count()`
* Add examples to docs
* Rephrase count in `BaseCache.__str__()` as 'total rows' to be less ambiguous, since the total may include invalid responses