### PR TITLE
Minor improvements for JSON serializer and Filesystem backend

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,9 +1,12 @@
 # History
 
 ### 0.7.3 (2021-08-TBD)
-* Update `DbCache.clear()` (SQLite) to succeed even if the database is corrupted
-* Update `DbDict.bulk_delete()` (SQLite) to split the operation into multiple statements to support
+* SQLite backend: Update `DbCache.clear()` to succeed even if the database is corrupted
+* SQLite backend: update `DbDict.bulk_delete()` to split the operation into multiple statements to support
   deleting more items than SQLite's variable limit (999)
+* Filesystem backend: When using JSON serializer, pretty-print JSON by default
+* Filesystem backend: Add an appropriate file extension to cache files (`.json`, `.yaml`, `.pkl`, etc.) by default.
+  Can be overridden or disabled with the `extension` parameter.
 * Add a `BaseCache.delete_urls()` method to bulk delete multiple responses from the cache based on request URL
 
 ### 0.7.2 (2021-07-21)

--- a/requests_cache/__init__.py
+++ b/requests_cache/__init__.py
@@ -16,13 +16,18 @@ def get_placeholder_class(original_exception: Exception = None):
     class Placeholder:
         msg = 'Dependencies are not installed for this feature'
 
-        def __init__(self, *args, **kwargs):
+        def _log_error(self):
             logger.error(self.msg)
             raise original_exception or ImportError(self.msg)
 
+        def __init__(self, *args, **kwargs):
+            self._log_error()
+
         def __getattr__(self, *args, **kwargs):
-            logger.error(self.msg)
-            raise original_exception or ImportError(self.msg)
+            self._log_error()
+
+        def dumps(self, *args, **kwargs):
+            self._log_error()
 
     return Placeholder
 

--- a/requests_cache/serializers/preconf.py
+++ b/requests_cache/serializers/preconf.py
@@ -11,6 +11,7 @@ class that raises an ``ImportError`` at initialization time instead of at import
 Requires python 3.7+.
 """
 import pickle
+from functools import partial
 
 from cattr.preconf import bson as bson_preconf
 from cattr.preconf import json as json_preconf
@@ -33,6 +34,7 @@ ujson_preconf_stage = CattrStage(ujson.make_converter)
 # Pickle serializer that uses the cattrs base converter
 pickle_serializer = SerializerPipeline([base_stage, pickle])
 
+
 # Pickle serializer with an additional stage using itsdangerous
 try:
     from itsdangerous import Signer
@@ -51,6 +53,7 @@ except ImportError as e:
     signer_stage = get_placeholder_class(e)
     safe_pickle_serializer = get_placeholder_class(e)
 
+
 # BSON serializer using either PyMongo's bson.json_util if installed, otherwise standalone bson codec
 try:
     try:
@@ -62,6 +65,7 @@ try:
 except ImportError as e:
     bson_serializer = get_placeholder_class(e)
 
+
 # JSON serailizer using ultrajson if installed, otherwise stdlib json
 try:
     import ujson as json
@@ -72,7 +76,10 @@ except ImportError:
 
     converter = json_preconf_stage
 
-json_serializer = SerializerPipeline([converter, json])
+json_stage = Stage(json)
+json_stage.dumps = partial(json.dumps, indent=2)
+json_serializer = SerializerPipeline([converter, json_stage])
+
 
 # YAML serializer using pyyaml
 try:

--- a/tests/integration/test_filesystem.py
+++ b/tests/integration/test_filesystem.py
@@ -1,9 +1,11 @@
 import pickle
+import pytest
 from os.path import isfile
 from shutil import rmtree
 from tempfile import gettempdir
 
 from requests_cache.backends import FileCache, FileDict
+from requests_cache.serializers import SERIALIZERS, SerializerPipeline
 from tests.integration.base_cache_test import BaseCacheTest
 from tests.integration.base_storage_test import CACHE_NAME, BaseStorageTest
 
@@ -27,14 +29,21 @@ class TestFileDict(BaseStorageTest):
         assert not relative_path.startswith(gettempdir())
         assert temp_path.startswith(gettempdir())
 
-    def test_paths(self):
-        cache = self.storage_class(CACHE_NAME)
+    @pytest.mark.parametrize('serializer_name', SERIALIZERS.keys())
+    def test_paths(self, serializer_name):
+        if not isinstance(SERIALIZERS[serializer_name], SerializerPipeline):
+            pytest.skip(f'Dependencies not installed for {serializer_name}')
+
+        cache = self.storage_class(CACHE_NAME, serializer=serializer_name)
+        cache.clear()
         for i in range(self.num_instances):
             cache[f'key_{i}'] = f'value_{i}'
 
+        expected_extension = serializer_name.replace('pickle', 'pkl')
         assert len(list(cache.paths())) == self.num_instances
         for path in cache.paths():
             assert isfile(path)
+            assert path.endswith(f'.{expected_extension}')
 
 
 class TestFileCache(BaseCacheTest):


### PR DESCRIPTION
* Pretty-print JSON by default
* Filesystem backend: Add an appropriate file extension to cache files (`.json`, `.yaml`, `.pkl`, etc.) by default.