### PR TITLE
Add option to use user cache dir (~/.cache, etc.) for SQLite and Filesystem backends

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,17 +3,39 @@
 ## 0.8.0 (TBD)
 [See all issues and PRs for 0.8](https://github.com/reclosedev/requests-cache/milestone/3?closed=1)
 
-**Cache headers:**
-* Add support for `ETag` + `If-None-Match` headers
-* Add support for `Last-Modified` + `If-Modified-Since` headers
-* Add handling for `304 Not Modified` responses if returned for any other reason
-  (e.g., request headers manually set by the client)
+**Conditional requests:**
+* Add support for the following request + response headers to enable conditional requests:
+  * `ETag` + `If-None-Match` headers
+  * `Last-Modified` + `If-Modified-Since` headers
+  * `304 Not Modified` responses
 
-**Backends:**:
+**Backends:**
+* Filesystem: Add `use_cache_dir` option to use platform-specific user cache directory
 * Filesystem: Add `FileCache.paths()` method
 * Filesystem: Fix issue in which `redirects.sqlite` would get included in response paths
+* SQLite: Add `use_cache_dir` option to use platform-specific user cache directory
 * SQLite: Add `use_memory` option and support for in-memory databases
 * SQLite: Add `SQLiteCache.db_path` property
+
+**Serialization:**
+* Use `cattrs` for serialization by default, which enables a more forwards-compatible serialization format
+  (e.g., less prone to invalidation due to future updates)
+
+**Other features:**
+* Add support for custom cache key callbacks with `key_fn` parameter
+
+**Depedencies:**
+* Require python 3.7+
+    * Note: python 3.6 support in 0.7.x will continue to be maintained until it reaches EOL (2021-12-23)
+    * Any bugfixes for 0.8 that also apply to 0.7 will be backported
+* Add new `appdirs` dependency (for user cache directories)
+* Update `cattrs` from optional to a required dependency
+* Update `itsdangerous` required to an optional dependency
+* Require requests 2.22+ and urllib3 1.25.5+
+
+**Deprecations & removals:**
+* Remove deprecated `core` module
+* Remove deprecated `BaseCache.remove_old_entries()` method
 * For consistency with other backends, rename:
   * `DbCache` -> `SQLiteCache`
   * `DbDict` -> `SQLiteDict`
@@ -21,19 +43,6 @@
   * `DynamoDbCache` -> `DynamoCache`
   * `DynamoDbDict` -> `DynamoDict`
   * Add aliases for previous names for backwards-compatibility
-
-**Serialization:**
-* Use `cattrs` for serialization by default, which enables a more forwards-compatible serialization format
-  (e.g., less prone to invalidation due to future updates)
-
-**Other Features:**
-* Add support for custom cache key callbacks
-
-**Breaking changes:**
-* Drop support for python 3.6
-    * Note: Any bugfixes for 0.8.x that also apply to 0.7.x will be backported
-* Remove deprecated `core` module
-* Remove deprecated `BaseCache.remove_old_entries()` method
 
 -----
 ### 0.7.4 (2021-08-16)

--- a/docs/security.md
+++ b/docs/security.md
@@ -13,6 +13,11 @@ Since this isn't always possible, requests-cache can optionally use
 It works by signing serialized data with a secret key that you control. Then, if the data is tampered
 with, the signature check fails and raises an error.
 
+Optional dependencies can be installed with:
+```bash
+pip install requests-cache[security]
+```
+
 ## Creating and Storing a Secret Key
 To enable this behavior, first create a secret key, which can be any `str` or `bytes` object.
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -7,6 +7,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "appdirs"
+version = "1.4.4"
+description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "argcomplete"
 version = "1.12.3"
 description = "Bash tab completion for argparse"
@@ -1181,12 +1189,16 @@ yaml = []
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "d73d313f19bec94728639a91b739ae34bd04d1f975716df3ae938db343328562"
+content-hash = "01c4c5d4ac701b6499db508b2334b5d51fbdc773e56193ced940e73c989edc17"
 
 [metadata.files]
 alabaster = [
     {file = "alabaster-0.7.12-py2.py3-none-any.whl", hash = "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359"},
     {file = "alabaster-0.7.12.tar.gz", hash = "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"},
+]
+appdirs = [
+    {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
+    {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
 ]
 argcomplete = [
     {file = "argcomplete-1.12.3-py2.py3-none-any.whl", hash = "sha256:291f0beca7fd49ce285d2f10e4c1c77e9460cf823eef2de54df0c0fec88b0d81"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -322,7 +322,7 @@ name = "itsdangerous"
 version = "2.0.1"
 description = "Safely pass data to untrusted environments and back."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.6"
 
 [[package]]
@@ -928,17 +928,24 @@ type_comments = ["typed-ast (>=1.4.0)"]
 
 [[package]]
 name = "sphinx-automodapi"
-version = "0.13"
+version = "0.14.dev0"
 description = "Sphinx extension for auto-generating API documentation for entire modules"
 category = "main"
 optional = true
 python-versions = ">=3.6"
+develop = false
 
 [package.dependencies]
 sphinx = ">=1.7"
 
 [package.extras]
 test = ["pytest", "pytest-cov", "cython", "codecov", "coverage (<5.0)"]
+
+[package.source]
+type = "git"
+url = "https://github.com/astropy/sphinx-automodapi.git"
+reference = "main"
+resolved_reference = "39609d0d712447c91ffd1809150ed71ff4ed0099"
 
 [[package]]
 name = "sphinx-copybutton"
@@ -1177,19 +1184,20 @@ docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [extras]
-all = ["boto3", "botocore", "pymongo", "redis", "ujson"]
+all = ["boto3", "botocore", "itsdangerous", "pymongo", "redis", "ujson"]
 bson = ["bson"]
 docs = ["furo", "linkify-it-py", "myst-parser", "Sphinx", "sphinx-autodoc-typehints", "sphinx-automodapi", "sphinx-copybutton", "sphinx-inline-tabs", "sphinxcontrib-apidoc"]
 dynamodb = ["boto3", "botocore"]
 json = ["ujson"]
 mongodb = ["pymongo"]
 redis = ["redis"]
+security = ["itsdangerous"]
 yaml = []
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "01c4c5d4ac701b6499db508b2334b5d51fbdc773e56193ced940e73c989edc17"
+content-hash = "afbbf4b6ac6452cfffde5c153cac6596f6e4a2b6d883390cf634b6253eab0782"
 
 [metadata.files]
 alabaster = [
@@ -1742,10 +1750,7 @@ sphinx-autodoc-typehints = [
     {file = "sphinx-autodoc-typehints-1.12.0.tar.gz", hash = "sha256:193617d9dbe0847281b1399d369e74e34cd959c82e02c7efde077fca908a9f52"},
     {file = "sphinx_autodoc_typehints-1.12.0-py3-none-any.whl", hash = "sha256:5e81776ec422dd168d688ab60f034fccfafbcd94329e9537712c93003bddc04a"},
 ]
-sphinx-automodapi = [
-    {file = "sphinx-automodapi-0.13.tar.gz", hash = "sha256:e1019336df7f7f0bcbf848eff7b84e7bef71691a57d8b5bda9107a2a046a226a"},
-    {file = "sphinx_automodapi-0.13-py3-none-any.whl", hash = "sha256:f9ebc9c10597f3aab1d93e5a8b1829903eee7c64f5bafb0cf71fd40e5c7d95f0"},
-]
+sphinx-automodapi = []
 sphinx-copybutton = [
     {file = "sphinx-copybutton-0.4.0.tar.gz", hash = "sha256:8daed13a87afd5013c3a9af3575cc4d5bec052075ccd3db243f895c07a689386"},
     {file = "sphinx_copybutton-0.4.0-py3-none-any.whl", hash = "sha256:4340d33c169dac6dd82dce2c83333412aa786a42dd01a81a8decac3b130dc8b0"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -1186,7 +1186,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [extras]
 all = ["boto3", "botocore", "itsdangerous", "pymongo", "redis", "ujson"]
 bson = ["bson"]
-docs = ["furo", "linkify-it-py", "myst-parser", "Sphinx", "sphinx-autodoc-typehints", "sphinx-automodapi", "sphinx-copybutton", "sphinx-inline-tabs", "sphinxcontrib-apidoc"]
+docs = ["furo", "linkify-it-py", "myst-parser", "sphinx", "sphinx-autodoc-typehints", "sphinx-automodapi", "sphinx-copybutton", "sphinx-inline-tabs", "sphinxcontrib-apidoc"]
 dynamodb = ["boto3", "botocore"]
 json = ["ujson"]
 mongodb = ["pymongo"]
@@ -1197,7 +1197,7 @@ yaml = []
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "afbbf4b6ac6452cfffde5c153cac6596f6e4a2b6d883390cf634b6253eab0782"
+content-hash = "cbefc1a12aa9008ac7b344c9cd9d111fc6a9118befa10b2ddb53c4e288eeb60b"
 
 [metadata.files]
 alabaster = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ include = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
+appdirs = "^1.4.4"
 attrs = "^21.2"
 cattrs = "^1.8"
 itsdangerous = "^2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,15 +29,9 @@ python = "^3.7"
 appdirs = "^1.4.4"
 attrs = "^21.2"
 cattrs = "^1.8"
-itsdangerous = "^2.0"
 requests = "^2.22"
 urllib3 = "^1.25.4"
 url-normalize = "^1.4"
-
-# Optional serialization dependencies
-bson = {version = ">=0.5", optional = true}
-pyyaml = {version = ">=5.4", optional = true}
-ujson = {version = ">=4.0", optional = true}
 
 # Optional backend dependencies
 boto3 = { version = "^1.15", optional = true }
@@ -45,26 +39,33 @@ botocore = { version = "^1.18", optional = true }
 pymongo = { version = "^3.0", optional = true }
 redis = { version = "^3.0", optional = true }
 
+# Optional serialization dependencies
+bson = {version = ">=0.5", optional = true}
+itsdangerous = {version = "^2.0", optional = true}
+pyyaml = {version = ">=5.4", optional = true}
+ujson = {version = ">=4.0", optional = true}
+
 # Documentation dependencies needed for Readthedocs builds (rtd doesn't support poetry.dev-dependencies)
 # [tool.poetry.dev-dependencies]
 furo = {version = ">=2021.8.11-beta.42", optional = true}
 myst-parser = {version = "^0.15.1", optional = true}
 Sphinx = { version = "4.1.2", optional = true }
 sphinx-autodoc-typehints = { version = "^1.11", optional = true }
-sphinx-automodapi = {version = "^0.13", optional = true}
+sphinx-automodapi = { git = "https://github.com/astropy/sphinx-automodapi.git", branch="main", optional = true }
 sphinx-copybutton = { version = ">=0.3,<0.5", optional = true }
 sphinx-inline-tabs = {version = "^2021.4.11-beta.9", optional = true, python = ">=3.8"}
 sphinxcontrib-apidoc = { version = "^0.3", optional = true }
 linkify-it-py = {version = "^1.0.1", optional = true}
 
 [tool.poetry.extras]
-all = ["boto3", "botocore", "pymongo", "redis", "ujson"]
+all = ["boto3", "botocore", "itsdangerous", "pymongo", "redis", "ujson"]
 bson = ["bson"]  # BSON comes with pymongo, and can also be used as a standalone codec
 json = ["ujson"]
 yaml = ["yaml"]
 dynamodb = ["boto3", "botocore"]
 mongodb = ["pymongo"]
 redis = ["redis"]
+security = ["itsdangerous"]
 docs = ["furo", "linkify-it-py", "myst-parser", "sphinx", "sphinx-autodoc-typehints",
         "sphinx-automodapi", "sphinx-copybutton", "sphinx-inline-tabs", "sphinxcontrib-apidoc"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,12 @@
 [tool.poetry]
 name = "requests-cache"
 version = "0.8.0"
-description = "A transparent, persistent cache for the requests library"
-authors = ["Roman Haritonov", "Jordan Cook"]
+description = "A transparent persistent cache for the requests library"
+authors = ["Roman Haritonov"]
+maintainers = ["Jordan Cook"]
 license = "BSD License"
 readme = "README.md"
+documentation = "https://requests-cache.readthedocs.io"
 homepage = "https://github.com/reclosedev/requests-cache"
 repository = "https://github.com/reclosedev/requests-cache"
 keywords = ["requests", "cache", "http", "persistence", "sqlite", "redis", "mongodb", "gridfs", "dynamodb"]
@@ -14,77 +16,89 @@ classifiers = [
     "Typing :: Typed",
 ]
 include = [
-    { path = "*.md", format = "sdist" },
-    { path = "*.yml", format = "sdist" },
-    { path = "docs", format = "sdist" },
-    { path = "examples", format = "sdist" },
-    { path = "tests", format = "sdist" },
+    {format="sdist", path="*.md"},
+    {format="sdist", path="*.yml"},
+    {format="sdist", path="docs"},
+    {format="sdist", path="examples"},
+    {format="sdist", path="tests"},
 ]
 
-[tool.poetry.urls]
-"Documentation" = "https://requests-cache.readthedocs.io"
-
 [tool.poetry.dependencies]
-python = "^3.7"
-appdirs = "^1.4.4"
-attrs = "^21.2"
-cattrs = "^1.8"
-requests = "^2.22"
-urllib3 = "^1.25.4"
-url-normalize = "^1.4"
+python        = "^3.7"
+
+# Required dependencies
+requests      = "^2.22"    # Needs no introduction
+urllib3       = "^1.25.5"  # Use a slightly newer version than required by requests (for bugfixes)
+appdirs       = "^1.4.4"   # For options that use platform-specific user cache dirs
+attrs         = "^21.2"    # For response data models
+cattrs        = "^1.8"     # For response serialization
+url-normalize = "^1.4"     # For reducing duplicate cache items
 
 # Optional backend dependencies
-boto3 = { version = "^1.15", optional = true }
-botocore = { version = "^1.18", optional = true }
-pymongo = { version = "^3.0", optional = true }
-redis = { version = "^3.0", optional = true }
+boto3                      = {optional=true, version="^1.15"}
+botocore                   = {optional=true, version="^1.18"}
+pymongo                    = {optional=true, version="^3.0"}
+redis                      = {optional=true, version="^3.0"}
 
 # Optional serialization dependencies
-bson = {version = ">=0.5", optional = true}
-itsdangerous = {version = "^2.0", optional = true}
-pyyaml = {version = ">=5.4", optional = true}
-ujson = {version = ">=4.0", optional = true}
+bson                       = {optional=true, version=">=0.5"}
+itsdangerous               = {optional=true, version="^2.0"}
+pyyaml                     = {optional=true, version=">=5.4"}
+ujson                      = {optional=true, version=">=4.0"}
 
-# Documentation dependencies needed for Readthedocs builds (rtd doesn't support poetry.dev-dependencies)
+# All the bells and whistles for building documentation;
+# defined here because readthedocs doesn't (yet?) support poetry.dev-dependencies
 # [tool.poetry.dev-dependencies]
-furo = {version = ">=2021.8.11-beta.42", optional = true}
-myst-parser = {version = "^0.15.1", optional = true}
-Sphinx = { version = "4.1.2", optional = true }
-sphinx-autodoc-typehints = { version = "^1.11", optional = true }
-sphinx-automodapi = { git = "https://github.com/astropy/sphinx-automodapi.git", branch="main", optional = true }
-sphinx-copybutton = { version = ">=0.3,<0.5", optional = true }
-sphinx-inline-tabs = {version = "^2021.4.11-beta.9", optional = true, python = ">=3.8"}
-sphinxcontrib-apidoc = { version = "^0.3", optional = true }
-linkify-it-py = {version = "^1.0.1", optional = true}
+furo                       = {optional=true, version=">=2021.8.11-beta.42"}
+linkify-it-py              = {optional=true, version="^1.0.1"}
+myst-parser                = {optional=true, version="^0.15.1"}
+sphinx                     = {optional=true, version="4.1.2"}
+sphinx-autodoc-typehints   = {optional=true, version="^1.11"}
+sphinx-automodapi          = {optional=true, branch="main", git="https://github.com/astropy/sphinx-automodapi.git"}  # Unreleased bugfixes
+sphinx-copybutton          = {optional=true, version=">=0.3,<0.5"}
+sphinx-inline-tabs         = {optional=true, version="^2021.4.11-beta.9", python=">=3.8"}
+sphinxcontrib-apidoc       = {optional=true, version="^0.3"}
 
 [tool.poetry.extras]
-all = ["boto3", "botocore", "itsdangerous", "pymongo", "redis", "ujson"]
-bson = ["bson"]  # BSON comes with pymongo, and can also be used as a standalone codec
-json = ["ujson"]
-yaml = ["yaml"]
+# Package extras for optional backend dependencies
 dynamodb = ["boto3", "botocore"]
-mongodb = ["pymongo"]
-redis = ["redis"]
+mongodb  = ["pymongo"]
+redis    = ["redis"]
+
+# Package extras for optional seriazliation dependencies
+bson     = ["bson"]   # BSON comes with pymongo, but can also be used as a standalone codec
+json     = ["ujson"]  # Will optionally be used by JSON serializer for improved performance
 security = ["itsdangerous"]
-docs = ["furo", "linkify-it-py", "myst-parser", "sphinx", "sphinx-autodoc-typehints",
-        "sphinx-automodapi", "sphinx-copybutton", "sphinx-inline-tabs", "sphinxcontrib-apidoc"]
+yaml     = ["yaml"]
+
+# All optional packages combined, for demo/evaluation purposes
+all      = ["boto3", "botocore", "itsdangerous", "pymongo", "redis", "ujson"]
+
+# Documentation
+docs     = ["furo", "linkify-it-py", "myst-parser", "sphinx", "sphinx-autodoc-typehints",
+            "sphinx-automodapi", "sphinx-copybutton", "sphinx-inline-tabs", "sphinxcontrib-apidoc"]
 
 [tool.poetry.dev-dependencies]
-mypy = "^0.910"
-nox = "^2021.6.12"
-nox-poetry = "^0.8.6"
-pre-commit = "^2.12"
-psutil = "^5.0"
-pytest = "^6.2"
-pytest-clarity = "^1.0.1"
-pytest-cov = ">=2.11"
-pytest-rerunfailures = "^10.1"
-pytest-xdist = ">=2.2"
-requests-mock = "^1.8"
-responses = "0.10.15"
-rich = ">=10.0"
-sphinx-autobuild = "^2021.3.14"
-timeout-decorator = "^0.5"
+# For unit + integration tests
+psutil                = "^5.0"
+pytest                = "^6.2"
+pytest-clarity        = "^1.0.1"
+pytest-cov            = ">=2.11"
+pytest-rerunfailures  = "^10.1"
+pytest-xdist          = ">=2.2"
+requests-mock         = "^1.8"
+responses             = "0.10.15"
+timeout-decorator     = "^0.5"
+
+# For linting, etc.; additional tools are managed by pre-commit
+mypy                  = "^0.910"
+pre-commit            = "^2.12"
+
+# For convenience in local development
+nox                   = "^2021.6.12"
+nox-poetry            = "^0.8.6"
+rich                  = ">=10.0"
+sphinx-autobuild      = "^2021.3.14"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/integration/test_filesystem.py
+++ b/tests/integration/test_filesystem.py
@@ -4,6 +4,7 @@ from shutil import rmtree
 from tempfile import gettempdir
 
 import pytest
+from appdirs import user_cache_dir
 
 from requests_cache.backends import FileCache, FileDict
 from requests_cache.serializers import SERIALIZERS, SerializerPipeline
@@ -23,6 +24,12 @@ class TestFileDict(BaseStorageTest):
         cache = self.storage_class(f'{CACHE_NAME}_{index}', serializer=pickle, use_temp=True, **kwargs)
         cache.clear()
         return cache
+
+    def test_use_cache_dir(self):
+        relative_path = self.storage_class(CACHE_NAME).cache_dir
+        cache_dir_path = self.storage_class(CACHE_NAME, use_cache_dir=True).cache_dir
+        assert not relative_path.startswith(user_cache_dir())
+        assert cache_dir_path.startswith(user_cache_dir())
 
     def test_use_temp(self):
         relative_path = self.storage_class(CACHE_NAME).cache_dir

--- a/tests/integration/test_sqlite.py
+++ b/tests/integration/test_sqlite.py
@@ -3,6 +3,8 @@ from tempfile import gettempdir
 from threading import Thread
 from unittest.mock import patch
 
+from appdirs import user_cache_dir
+
 from requests_cache.backends.base import BaseCache
 from requests_cache.backends.sqlite import MEMORY_URI, SQLiteCache, SQLiteDict, SQLitePickleDict
 from tests.integration.base_cache_test import BaseCacheTest
@@ -18,6 +20,12 @@ class SQLiteTestCase(BaseStorageTest):
             os.unlink(f'{CACHE_NAME}.sqlite')
         except Exception:
             pass
+
+    def test_use_cache_dir(self):
+        relative_path = self.storage_class(CACHE_NAME).db_path
+        cache_dir_path = self.storage_class(CACHE_NAME, use_cache_dir=True).db_path
+        assert not relative_path.startswith(user_cache_dir())
+        assert cache_dir_path.startswith(user_cache_dir())
 
     def test_use_temp(self):
         relative_path = self.storage_class(CACHE_NAME).db_path


### PR DESCRIPTION
Adds [appdirs](https://github.com/ActiveState/appdirs) as a dependency. It's a tiny and ubiquitous library, and I think this is a common enough use case that it's worth it.

Can anyone think of a decent parameter name for this? Similar existing options are `use_temp` and `use_memory`.

`use_cache` or `cache_dir` are ambiguous, `use_cache_dir` is too close to (appdirs.)`user_cache_dir`, and `use_user_cache_dir` is rather verbose, and can't think of any better options at the moment.