### PR TITLE
Use blake2 instead of sha256 for hashing request info

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -16,6 +16,7 @@
     * Add `FileCache.paths()` method
     * Add `use_cache_dir` option to use platform-specific user cache directory
     * Return `pathlib.Path` objects for all file paths
+    * Use shorter hashes for file names
 * SQLite:
     * Add `SQLiteCache.db_path` wrapper property
     * Add `use_memory` option and support for in-memory databases
@@ -31,6 +32,7 @@
 * Allow `create_key()` to optionally accept arguments for `requests.Request` instead of a request object
 * Allow `match_headers` to optionally accept a list of specific headers to match
 * Add support for custom cache key callbacks with `key_fn` parameter
+* By default use blake2 instead of sha256 for generating cache keys
 * Slightly reduce size of serialized responses
 
 **Depedencies:**
@@ -126,8 +128,8 @@
 * Add more detailed repr methods for `CachedSession`, `CachedResponse`, and `BaseCache`
 * Add support for caching multipart form uploads
 * Update `BaseCache.urls` to only skip invalid responses, not delete them (for better performance)
-* Update `old_data_on_error` option to also handle error response codes
 * Update `ignored_parameters` to also exclude ignored request params, body params, or headers from cached response data (to avoid storing API keys or other credentials)
+* Update `old_data_on_error` option to also handle error response codes
 * Only log request exceptions if `old_data_on_error` is set
 
 **Depedencies:**

--- a/requests_cache/cache_keys.py
+++ b/requests_cache/cache_keys.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 import json
-from hashlib import sha256
+from hashlib import blake2b
 from operator import itemgetter
 from typing import TYPE_CHECKING, Dict, Iterable, List, Mapping, Optional, Tuple, Union
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
@@ -44,7 +44,8 @@ def create_key(
         assert request is not None
 
     # Add method and relevant request settings
-    key = sha256(encode((request.method or '').upper()))
+    key = blake2b(digest_size=8)
+    key.update(encode((request.method or '').upper()))
     key.update(encode(kwargs.get('verify', True)))
 
     # Add filtered/normalized URL + request params

--- a/tests/unit/test_cache_keys.py
+++ b/tests/unit/test_cache_keys.py
@@ -16,7 +16,7 @@ def test_normalize_dict__skip_body():
     assert normalize_dict(b'some bytes', normalize_data=False) == b'some bytes'
 
 
-CACHE_KEY = '60f16f69ec5a24991e4e58ded8d92bd78f1b8468a5e0ac8db7533d5cb113f7f2'
+CACHE_KEY = 'f8cd92cfe57ddbf9'
 
 
 # All of the following variations should produce the same cache key

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -384,8 +384,9 @@ def test_response_defaults(mock_session):
     response_1 = mock_session.get(MOCKED_URL)
     response_2 = mock_session.get(MOCKED_URL)
     response_3 = mock_session.get(MOCKED_URL)
+    cache_key = '71c046cdb0afaa62'
 
-    assert response_1.cache_key.startswith('fd2afc8d')
+    assert response_1.cache_key == cache_key
     assert response_1.created_at is None
     assert response_1.expires is None
     assert response_1.from_cache is False
@@ -393,7 +394,7 @@ def test_response_defaults(mock_session):
 
     assert isinstance(response_2.created_at, datetime)
     assert isinstance(response_2.expires, datetime)
-    assert response_2.cache_key.startswith('fd2afc8d')
+    assert response_2.cache_key == cache_key
     assert response_2.created_at == response_3.created_at
     assert response_2.expires == response_3.expires
     assert response_2.from_cache is response_3.from_cache is True


### PR DESCRIPTION
With an 8-byte digest for shorter cache keys. This is still plenty long enough to avoid hash collisions: `4e-15` probability for 100,000 items, `4e-7` for 1 billion items, etc.

This makes it more convenient for manually inspecting cache items, especially for the filesystem backend, which uses cache keys as filenames.