### PR TITLE
Add better error message if parent path exists but isn't a directory

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@
 ## 0.8.2 (Unreleased)
 * Use `Cache-Control` **request** headers by default
 * Support `expire_after` param for `CachedSession.send()`
+* Filesystem and SQLite backends: Add better error message if parent path exists but isn't a directory
 * Make per-request expiration thread-safe for both `CachedSession.request()` and `CachedSession.send()`
 * Handle some additional corner cases when normalizing request data
 * Some micro-optimizations for request matching

--- a/tests/integration/test_sqlite.py
+++ b/tests/integration/test_sqlite.py
@@ -1,8 +1,10 @@
 import os
-from tempfile import gettempdir
+from os.path import join
+from tempfile import NamedTemporaryFile, gettempdir
 from threading import Thread
 from unittest.mock import patch
 
+import pytest
 from appdirs import user_cache_dir
 
 from requests_cache.backends.base import BaseCache
@@ -50,6 +52,13 @@ class SQLiteTestCase(BaseStorageTest):
 
     def test_use_memory__uri(self):
         self.init_cache(':memory:').db_path == ':memory:'
+
+    def test_non_dir_parent_exists(self):
+        """Expect a custom error message if a parent path already exists but isn't a directory"""
+        with NamedTemporaryFile() as tmp:
+            with pytest.raises(FileExistsError) as exc_info:
+                self.storage_class(join(tmp.name, 'invalid_path'))
+                assert 'not a directory' in str(exc_info.value)
 
     def test_bulk_commit(self):
         cache = self.init_cache()


### PR DESCRIPTION
Fixes #433

Instead of a confusing error message like:
```
AttributeError: 'SQLiteDict' object has no attribute '_local_context'`
```

Show this error message:
```
FileExistsError: Parent path exists and is not a directory: <path>. Please either delete the file or choose a different path.
```

This applies to `SQLiteDict`, `SQLitePickleDict`, and `FileDict`.

This also creates `_local_context` earlier in `SQLiteDict.__init__()` so any other potential initialization errors won't attempt to reference `_local_context` before it's created.
