### PR TITLE
Add back overrides for requests.Response.__getstate__ and __setstate__ so plain pickle will work as a serializer

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -25,6 +25,7 @@
 * Add support for `BaseCache` keyword arguments passed along with a backend instance
 * Fix issue with cache headers not being used correctly if `cache_control=True` is used with an `expire_after` value
 * Fix license metadata as shown on PyPI
+* Fix `CachedResponse` serialization behavior when using stdlib `pickle` in a custom serializer
 
 ## 0.8.1 (2021-09-15)
 * Redact `ingored_parameters` from `CachedResponse.url` (if used for credentials or other sensitive info)

--- a/requests_cache/models/response.py
+++ b/requests_cache/models/response.py
@@ -105,6 +105,15 @@ class CachedResponse(Response):
         """Get the size of the response body in bytes"""
         return len(self.content) if self.content else 0
 
+    def __getstate__(self):
+        """Override pickling behavior from ``requests.Response.__getstate__``"""
+        return self.__dict__
+
+    def __setstate__(self, state):
+        """Override pickling behavior from ``requests.Response.__setstate__``"""
+        for name, value in state.items():
+            setattr(self, name, value)
+
     def __str__(self):
         return (
             f'request: {self.request}, response: {self.status_code} '

--- a/tests/unit/test_serializers.py
+++ b/tests/unit/test_serializers.py
@@ -2,6 +2,7 @@
 # Any additional serializer-specific tests can go here.
 import gzip
 import json
+import pickle
 import sys
 from importlib import reload
 from unittest.mock import patch
@@ -93,3 +94,15 @@ def test_custom_serializer(tempfile_path):
     response = CachedResponse()
     session.cache.responses['key'] = response
     assert session.cache.responses['key'] == response
+
+
+def test_plain_pickle(tempfile_path):
+    """`requests.Response` modifies pickling behavior. If plain `pickle` is used as a serializer,
+    serializing `CachedResponse` should still work as expected.
+    """
+    session = CachedSession(tempfile_path, serializer=pickle)
+
+    response = CachedResponse()
+    session.cache.responses['key'] = response
+    assert session.cache.responses['key'] == response
+    assert session.cache.responses['key'].expires is None


### PR DESCRIPTION
Fixes #452 