### PR TITLE
Fix conditinal request expiration

### DIFF
--- a/requests_cache/backends/base.py
+++ b/requests_cache/backends/base.py
@@ -92,8 +92,12 @@ class BaseCache:
             expire_after: Time in seconds until this cache item should expire
         """
         cache_key = cache_key or self.create_key(response.request)
-        cached_response = CachedResponse.from_response(response, expires=expires)
-        cached_response = redact_response(cached_response, self.ignored_parameters)
+        if isinstance(response, CachedResponse):
+            cached_response = response
+            cached_response.expires = expires
+        else:
+            cached_response = CachedResponse.from_response(response, expires=expires)
+            cached_response = redact_response(cached_response, self.ignored_parameters)
         self.responses[cache_key] = cached_response
         for r in response.history:
             self.redirects[self.create_key(r.request)] = cache_key

--- a/requests_cache/backends/base.py
+++ b/requests_cache/backends/base.py
@@ -92,12 +92,8 @@ class BaseCache:
             expire_after: Time in seconds until this cache item should expire
         """
         cache_key = cache_key or self.create_key(response.request)
-        if isinstance(response, CachedResponse):
-            cached_response = response
-            cached_response.expires = expires
-        else:
-            cached_response = CachedResponse.from_response(response, expires=expires)
-            cached_response = redact_response(cached_response, self.ignored_parameters)
+        cached_response = CachedResponse.from_response(response, expires=expires)
+        cached_response = redact_response(cached_response, self.ignored_parameters)
         self.responses[cache_key] = cached_response
         for r in response.history:
             self.redirects[self.create_key(r.request)] = cache_key

--- a/requests_cache/models/response.py
+++ b/requests_cache/models/response.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta, timezone
 from logging import getLogger
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
+import attr
 from attr import define, field
 from requests import PreparedRequest, Response
 from requests.cookies import RequestsCookieJar
@@ -46,9 +47,13 @@ class CachedResponse(Response):
             self.raw.headers = HTTPHeaderDict(self.headers)
 
     @classmethod
-    def from_response(cls, original_response: Response, **kwargs):
-        """Create a CachedResponse based on an original response object"""
-        obj = cls(**kwargs)
+    def from_response(
+        cls, original_response: Union[Response, 'CachedResponse'], expires: datetime = None, **kwargs
+    ):
+        """Create a CachedResponse based on an original Response or another CachedResponse object"""
+        if isinstance(original_response, CachedResponse):
+            return attr.evolve(original_response, expires=expires)
+        obj = cls(expires=expires, **kwargs)
 
         # Copy basic attributes
         for k in Response.__attrs__:

--- a/requests_cache/session.py
+++ b/requests_cache/session.py
@@ -180,7 +180,12 @@ class CacheMixin(MIXIN_BASE):
         if self._is_cacheable(response, actions):
             self.cache.save_response(response, actions.cache_key, actions.expires)
         elif cached_response and response.status_code == 304:
-            logger.debug(f'Response for URL {request.url} has not been modified; using cached response')
+            logger.debug(
+                f'Response for URL {request.url} has not been modified; using cached response and updating expiration date.'
+            )
+            # Update the cache expiration date. Since we performed validation,
+            # the cache entry may be marked as fresh again.
+            self.cache.save_response(cached_response, actions.cache_key, actions.expires)
             return cached_response
         else:
             logger.debug(f'Skipping cache write for URL: {request.url}')


### PR DESCRIPTION
Closes #464 

- Update `CacheMixin`s `_send_and_cache` function to save CachedResponse with updated expiration date upon received 304 before returning the cached value.
- Update `BaseCache`s `save_response` function to only create a `CachedResponse` instance if the argument is not already of type `CachedResponse`