### PR TITLE
Switch to a different method of resolving ForwardRefs during deserialization for python 3.10.2 compatibility

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,8 @@
 # History
 
 ## 0.9.1 (Unreleased)
-* Add support for key-only request parameters
+* Add support for python 3.10.2 (regarding resolving `ForwardRef` types during deserialization)
+* Add support for key-only request parameters (regarding hashing request data for cache key creation)
 * Reduce verbosity of log messages when encountering an invalid JSON request body
 
 ## 0.9.0 (2022-01-01)

--- a/requests_cache/serializers/cattrs.py
+++ b/requests_cache/serializers/cattrs.py
@@ -65,10 +65,10 @@ def init_converter(factory: Callable[..., GenConverter] = None):
     converter.register_unstructure_hook(HTTPHeaderDict, dict)
     converter.register_structure_hook(HTTPHeaderDict, lambda obj, cls: HTTPHeaderDict(obj))
 
-    # Tell cattrs that a 'CachedResponse' forward ref is equivalent to the CachedResponse class
-    converter.register_structure_hook(
-        ForwardRef('CachedResponse'),
-        lambda obj, cls: converter.structure(obj, CachedResponse),
+    # Tell cattrs to resolve forward references (required for CachedResponse.history)
+    converter.register_structure_hook_func(
+        lambda cls: cls.__class__ is ForwardRef,
+        lambda obj, cls: converter.structure(obj, cls.__forward_value__),
     )
 
     return converter


### PR DESCRIPTION
Closes #501