### PR TITLE
Skip empty body decode/encode in normalize_json_body

### DIFF
--- a/requests_cache/cache_keys.py
+++ b/requests_cache/cache_keys.py
@@ -161,6 +161,10 @@ def normalize_json_body(
     original_body: Union[str, bytes], ignored_parameters: ParamList
 ) -> Union[str, bytes]:
     """Normalize and filter a request body with serialized JSON data"""
+
+    if len(original_body) == 0:
+        return original_body
+
     try:
         body = json.loads(decode(original_body))
         body = filter_sort_dict(body, ignored_parameters)


### PR DESCRIPTION
There's no point to decode/encode empty input. It will always fail and original be returned

See https://github.com/reclosedev/requests-cache/issues/494#issuecomment-1028486377