### PR TITLE
Fix handling BSON serializer differences between pymongo's bson and standalone bson codec

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## 0.9.3 (Unreleased)
+* Fix handling BSON serializer differences between pymongo's `bson` and standalone `bson` codec.
+
 ## 0.9.2 (2022-02-15)
 * Fix serialization in filesystem backend with binary content that is also valid UTF-8
 * Fix some regression bugs introduced in 0.9.0:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "requests-cache"
-version = "0.9.2"
+version = "0.9.3"
 description = "A transparent persistent cache for the requests library"
 authors = ["Roman Haritonov"]
 maintainers = ["Jordan Cook"]

--- a/requests_cache/serializers/preconf.py
+++ b/requests_cache/serializers/preconf.py
@@ -69,13 +69,15 @@ except ImportError as e:
 # BSON serializer
 try:
     try:
-        from bson import json_util as bson
+        from bson import decode as _bson_loads
+        from bson import encode as _bson_dumps
     except ImportError:
-        import bson
+        from bson import dumps as _bson_dumps
+        from bson import loads as _bson_loads
 
     bson_serializer = SerializerPipeline(
-        [bson_preconf_stage, bson], is_binary=False
-    )  #: Complete BSON serializer; uses pymongo's ``bson.json_util`` if installed, otherwise standalone ``bson`` codec
+        [bson_preconf_stage, Stage(dumps=_bson_dumps, loads=_bson_loads)], is_binary=True
+    )  #: Complete BSON serializer; uses pymongo's ``bson`` if installed, otherwise standalone ``bson`` codec
 except ImportError as e:
     bson_serializer = get_placeholder_class(e)
 

--- a/tests/integration/test_filesystem.py
+++ b/tests/integration/test_filesystem.py
@@ -60,7 +60,7 @@ class TestFileCache(BaseCacheTest):
         session = self.init_session(serializer=serializer_name)
         num_files = 20
         for i in range(num_files):
-            session.cache.responses[f'key_{i}'] = f'value_{i}'
+            session.cache.responses[f'key_{i}'] = {f'value_{i}': i}
 
         expected_extension = serializer_name.replace('pickle', 'pkl')
         assert len(list(session.cache.paths())) == num_files


### PR DESCRIPTION
Fixes #507 (again)

I was previously using  [bson.json_util.dumps()/loads()](https://pymongo.readthedocs.io/en/stable/api/bson/json_util.html), the purpose of which I misunderstood. This PR uses `bson.encode()`/decode()` instead, and correctly sets the serializer type to binary.

**Note:** When the standalone `bson` codec is installed instead of `pymongo`, the functions are named `bson.dumps()/loads()`, which is why the exception was needed in the first place.