### PR TITLE
Fix cache path expansion

### DIFF
--- a/requests_cache/backends/sqlite.py
+++ b/requests_cache/backends/sqlite.py
@@ -306,7 +306,7 @@ def get_cache_path(db_path: AnyPath, use_cache_dir: bool = False, use_temp: bool
         db_path = Path(gettempdir()) / db_path
 
     # Expand relative and user paths (~), make parent dir(s), and better error if parent is a file
-    db_path = db_path.absolute().expanduser()
+    db_path = db_path.expanduser().absolute()
     try:
         db_path.parent.mkdir(parents=True, exist_ok=True)
     except FileExistsError:

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -4,6 +4,7 @@ import json
 import time
 from collections import UserDict, defaultdict
 from datetime import datetime, timedelta
+from pathlib import Path
 from pickle import PickleError
 from unittest.mock import patch
 from urllib.parse import urlencode
@@ -33,6 +34,11 @@ YESTERDAY = datetime.utcnow() - timedelta(days=1)
 def test_init_unregistered_backend():
     with pytest.raises(ValueError):
         CachedSession(backend='nonexistent')
+
+
+def test_cache_path_expansion():
+    session = CachedSession('~', backend='filesystem')
+    assert session.cache.cache_dir == Path("~").expanduser()
 
 
 @patch.dict(BACKEND_CLASSES, {'mongo': get_placeholder_class()})


### PR DESCRIPTION
Calling `absolute()` before `expanduser()` results in `~/...` being expanded to `$PWD/~/...` instead of `/home/user/...`.

### Checklist
- [x] Added test coverage

