### PR TITLE
Add additional revalidation conditions, and new keyword arguments for request() and send()

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,15 @@
 # History
 
-## 0.9.3 (2022-02-22)
+## 0.10.0 (Unreleased)
+[See all issues and PRs for 0.10](https://github.com/reclosedev/requests-cache/milestone/5?closed=1)
+
+**Expiration & Headers:**
+* Add `refresh` option to `CachedSession.request()` and `send()` to make (and cache) an new request regardless of existing cache contents
+* Add `revalidate` option to `CachedSession.request()` and `send()` to send conditional request (if possible) before using a cached response
+* Revalidate for `Cache-Control: no-cache` request or response header
+* Revalidate for `Cache-Control: max-age=0, must-revalidate` response headers
+
+### 0.9.3 (2022-02-22)
 * Fix handling BSON serializer differences between pymongo's `bson` and standalone `bson` codec.
 * Handle `CorruptGridFile` error in GridFS backend
 * Fix cache path expansion for user directories (`~/...`) for SQLite and filesystem backends
@@ -12,13 +21,13 @@
     before it is read by a different thread
   * Fix multiple race conditions in GridFS backend
 
-## 0.9.2 (2022-02-15)
+### 0.9.2 (2022-02-15)
 * Fix serialization in filesystem backend with binary content that is also valid UTF-8
 * Fix some regression bugs introduced in 0.9.0:
   * Add support for `params` as a positional argument to `CachedSession.request()`
   * Add support for disabling expiration for a single request with `CachedSession.request(..., expire_after=-1)`
 
-## 0.9.1 (2022-01-15)
+### 0.9.1 (2022-01-15)
 * Add support for python 3.10.2 and 3.9.10 (regarding resolving `ForwardRef` types during deserialization)
 * Add support for key-only request parameters (regarding hashing request data for cache key creation)
 * Reduce verbosity of log messages when encountering an invalid JSON request body
@@ -53,7 +62,7 @@
 * Fix license metadata as shown on PyPI
 * Fix `CachedResponse` serialization behavior when using stdlib `pickle` in a custom serializer
 
-## 0.8.1 (2021-09-15)
+### 0.8.1 (2021-09-15)
 * Redact `ingored_parameters` from `CachedResponse.url` (if used for credentials or other sensitive info)
 * Fix an incorrect debug log message about skipping cache write
 * Add some additional aliases for `DbDict`, etc. so fully qualified imports don't break
@@ -248,8 +257,9 @@ Thanks to [Code Shelter](https://www.codeshelter.co) and [contributors](https://
 * Make default table names consistent across backends (`'http_cache'`)
 
 **Expiration:**
-* Cached responses are now stored with an absolute expiration time, so `CachedSession.expire_after` no longer applies retroactively. To revalidate previously cached items with a new expiration time see below:
-* Add support for overriding original expiration (i.e., revalidating) in `CachedSession.remove_expired_responses()`
+* Cached responses are now stored with an absolute expiration time, so `CachedSession.expire_after`
+  no longer applies retroactively. To reset expiration for previously cached items, see below:
+* Add support for overriding original expiration in `CachedSession.remove_expired_responses()`
 * Add support for setting expiration for individual requests
 * Add support for setting expiration based on URL glob patterns
 * Add support for setting expiration as a `datetime`

--- a/docs/user_guide/compatibility.md
+++ b/docs/user_guide/compatibility.md
@@ -1,4 +1,3 @@
-<!-- TODO: Fix relative links -->
 (compatibility)=
 # {fa}`plus-square` Usage with other requests-based libraries
 This library works by patching and/or extending {py:class}`requests.Session`. Many other libraries

--- a/docs/user_guide/expiration.md
+++ b/docs/user_guide/expiration.md
@@ -113,8 +113,7 @@ Or, when using patching:
 >>> requests_cache.remove_expired_responses()
 ```
 
-You can also apply a different `expire_after` to previously cached responses, which will
-revalidate the cache with the new expiration time:
+You can also apply a new `expire_after` value to previously cached responses:
 ```python
 >>> session.remove_expired_responses(expire_after=timedelta(days=30))
 ```

--- a/docs/user_guide/headers.md
+++ b/docs/user_guide/headers.md
@@ -47,15 +47,17 @@ The following headers are currently supported:
 
 **Request headers:**
 - `Cache-Control: max-age`: Used as the expiration time in seconds
-- `Cache-Control: no-cache`: Skip reading from the cache
+- `Cache-Control: no-cache`: Revalidate with the server before using a cached response
 - `Cache-Control: no-store`: Skip reading from and writing to the cache
-- `If-None-Match`: Automatically added if an `ETag` is available
-- `If-Modified-Since`: Automatically added if `Last-Modified` is available
+- `If-None-Match`: Automatically added for revalidation, if an `ETag` is available
+- `If-Modified-Since`: Automatically added for revalidation, if `Last-Modified` is available
 
 **Response headers:**
 - `Cache-Control: max-age`: Used as the expiration time in seconds
+- `Cache-Control: must-revalidate`: When used in combination with `max-age=0`, revalidate immediately.
+- `Cache-Control: no-cache`: Revalidate with the server before using a cached response
 - `Cache-Control: no-store` Skip writing to the cache
 - `Cache-Control: immutable`: Cache the response with no expiration
-- `Expires`: Used as an absolute expiration time
-- `ETag`: Return expired cache data if the remote content has not changed (`304 Not Modified` response)
-- `Last-Modified`: Return expired cache data if the remote content has not changed (`304 Not Modified` response)
+- `Expires`: Used as an absolute expiration datetime
+- `ETag`: Used for revalidation; update and return stale cache data if the remote content has not changed (`304 Not Modified` response)
+- `Last-Modified`: Used for revalidation; update and return stale cache data if the remote content has not changed (`304 Not Modified` response)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,3 +144,6 @@ skip = [
     'tests/compat/',
 ]
 known_first_party = ['tests']
+
+[tool.mypy]
+ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "requests-cache"
-version = "0.9.3"
+version = "0.10.0"
 description = "A transparent persistent cache for the requests library"
 authors = ["Roman Haritonov"]
 maintainers = ["Jordan Cook"]

--- a/requests_cache/__init__.py
+++ b/requests_cache/__init__.py
@@ -5,7 +5,7 @@ logger = getLogger('requests_cache')
 
 # Version is defined in pyproject.toml.
 # It's copied here to make it easier for client code to check the installed version.
-__version__ = '0.9.3'
+__version__ = '0.10.0'
 
 try:
     from .backends import *

--- a/requests_cache/cache_control.py
+++ b/requests_cache/cache_control.py
@@ -15,10 +15,11 @@ from email.utils import parsedate_to_datetime
 from fnmatch import fnmatch
 from logging import getLogger
 from math import ceil
-from typing import TYPE_CHECKING, Any, Dict, Mapping, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, Mapping, MutableMapping, Optional, Tuple, Union
 
 from attr import define, field
 from requests import PreparedRequest, Response
+from requests.models import CaseInsensitiveDict
 
 from ._utils import coalesce
 
@@ -152,6 +153,17 @@ class CacheActions:
         # Otherwise, skip writing to the cache if specified by expiration or other headers
         expire_immediately = try_int(self.expire_after) == DO_NOT_CACHE
         self.skip_write = (expire_immediately or no_store) and not has_validator
+
+
+def append_directive(
+    headers: Optional[MutableMapping[str, str]], directive: str
+) -> MutableMapping[str, str]:
+    """Append a Cache-Control directive to existing headers (if any)"""
+    headers = CaseInsensitiveDict(headers)
+    directives = headers['Cache-Control'].split(',') if headers.get('Cache-Control') else []
+    directives.append(directive)
+    headers['Cache-Control'] = ','.join(directives)
+    return headers
 
 
 def get_expiration_datetime(expire_after: ExpirationTime) -> Optional[datetime]:

--- a/requests_cache/models/response.py
+++ b/requests_cache/models/response.py
@@ -111,7 +111,7 @@ class CachedResponse(Response):
         """Returns a PreparedRequest for the next request in a redirect chain, if there is one."""
         return self._next.prepare() if self._next else None
 
-    def revalidate(self, expire_after: ExpirationTime) -> bool:
+    def reset_expiration(self, expire_after: ExpirationTime) -> bool:
         """Set a new expiration for this response, and determine if it is now expired"""
         self.expires = get_expiration_datetime(expire_after)
         return self.is_expired

--- a/requests_cache/patcher.py
+++ b/requests_cache/patcher.py
@@ -124,10 +124,10 @@ def clear():
 
 
 def remove_expired_responses(expire_after: ExpirationTime = None):
-    """Remove expired responses from the cache, optionally with revalidation
+    """Remove expired responses from the cache, and optionally reset expiration
 
     Args:
-        expire_after: A new expiration time used to revalidate the cache
+        expire_after: A new expiration time to set on existing cache items
     """
     session = requests.Session()
     if isinstance(session, CachedSession):

--- a/requests_cache/session.py
+++ b/requests_cache/session.py
@@ -73,7 +73,7 @@ class CacheMixin(MIXIN_BASE):
         session_kwargs = get_valid_kwargs(super().__init__, kwargs)
         super().__init__(**session_kwargs)  # type: ignore
 
-    def request(  # type: ignore  # Note: An extra param (expire_after) is added here
+    def request(  # type: ignore
         self,
         method: str,
         url: str,
@@ -81,12 +81,13 @@ class CacheMixin(MIXIN_BASE):
         expire_after: ExpirationTime = None,
         headers: MutableMapping[str, str] = None,
         refresh: bool = False,
+        revalidate: bool = False,
         **kwargs,
     ) -> AnyResponse:
         """This method prepares and sends a request while automatically performing any necessary
         caching operations. This will be called by any other method-specific ``requests`` functions
-        (get, post, etc.). This does not include prepared requests, which will still be cached via
-        ``send()``.
+        (get, post, etc.). This is not used by :py:class:`~requests.PreparedRequest` objects, which
+        are handled by :py:meth:`send()`.
 
         See :py:meth:`requests.Session.request` for parameters. Additional parameters:
 
@@ -94,7 +95,8 @@ class CacheMixin(MIXIN_BASE):
             expire_after: Expiration time to set only for this request; see details below.
                 Overrides ``CachedSession.expire_after``. Accepts all the same values as
                 ``CachedSession.expire_after``. Use ``-1`` to disable expiration.
-            refresh: Always make a new request, and overwrite any previously cached response.
+            refresh: Always make a new request, and overwrite any previously cached response
+            revalidate: Revalidate with the server before using a cached response (e.g., a "soft refresh")
 
         Returns:
             Either a new or cached response
@@ -109,11 +111,14 @@ class CacheMixin(MIXIN_BASE):
         6. :py:meth:`requests.Session.send` (if not previously cached)
         7. :py:meth:`.BaseCache.save_response` (if not previously cached)
         """
-        # Set any extra options as request headers to be handled in send()
+        # Set extra options as headers to be handled in send(), since we can't pass args directly
+        headers = headers or {}
         if expire_after is not None:
             headers = append_directive(headers, f'max-age={get_expiration_seconds(expire_after)}')
+        if revalidate:
+            headers = append_directive(headers, 'no-cache')
         if refresh:
-            headers = append_directive(headers, 'no-cache')  # Skip cache read, but not write
+            headers['requests-cache-refresh'] = 'true'
         kwargs['headers'] = headers
 
         with patch_form_boundary(**kwargs):
@@ -124,6 +129,7 @@ class CacheMixin(MIXIN_BASE):
         request: PreparedRequest,
         expire_after: ExpirationTime = None,
         refresh: bool = False,
+        revalidate: bool = False,
         **kwargs,
     ) -> AnyResponse:
         """Send a prepared request, with caching. See :py:meth:`.request` for notes on behavior, and
@@ -131,7 +137,8 @@ class CacheMixin(MIXIN_BASE):
 
         Args:
             expire_after: Expiration time to set only for this request
-            refresh: Always make a new request, and overwrite any previously cached response.
+            refresh: Always make a new request, and overwrite any previously cached response
+            revalidate: Revalidate with the server before using a cached response (e.g., a "soft refresh")
         """
         # Determine which actions to take based on request info and cache settings
         cache_key = self.cache.create_key(request, **kwargs)
@@ -142,10 +149,10 @@ class CacheMixin(MIXIN_BASE):
             session_expire_after=self.expire_after,
             urls_expire_after=self.urls_expire_after,
             cache_control=self.cache_control,
+            refresh=refresh,
+            revalidate=revalidate,
             **kwargs,
         )
-        if refresh:
-            actions.skip_read = True
 
         # Attempt to fetch a cached response
         cached_response: Optional[CachedResponse] = None
@@ -155,8 +162,8 @@ class CacheMixin(MIXIN_BASE):
         is_expired = getattr(cached_response, 'is_expired', False)
 
         # If the response is expired or missing, or the cache is disabled, then fetch a new response
-        if cached_response is None:
-            response = self._send_and_cache(request, actions, **kwargs)
+        if cached_response is None or actions.revalidate:
+            response = self._send_and_cache(request, actions, cached_response, **kwargs)
         elif is_expired and self.stale_if_error:
             response = self._resend_and_ignore(request, actions, cached_response, **kwargs)
         elif is_expired:
@@ -197,7 +204,8 @@ class CacheMixin(MIXIN_BASE):
         If applicable, also add headers to make a conditional request. If we get a 304 Not Modified
         response, return the stale cache item.
         """
-        request.headers.update(actions.validation_headers)
+        if actions.revalidate:
+            request.headers.update(actions.validation_headers)
         response = super().send(request, **kwargs)
         actions.update_from_response(response)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,8 +9,3 @@ ignore =
     E501  # line too long
     W503  # line break before binary operator
     W504  # line break after  binary operator
-
-# Tell mypy to ignore external libraries without type annotations
-# TODO: Next release may add support for pyproject.toml config
-[mypy]
-ignore_missing_imports = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,6 +55,7 @@ ETAG = '"644b5b0155e6404a9cc4bd9d8b1ae730"'
 LAST_MODIFIED = 'Thu, 05 Jul 2012 15:31:30 GMT'
 
 MOCKED_URL = 'http+mock://requests-cache.com/text'
+MOCKED_URL_ETAG = 'http+mock://requests-cache.com/etag'
 MOCKED_URL_HTTPS = 'https+mock://requests-cache.com/text'
 MOCKED_URL_JSON = 'http+mock://requests-cache.com/json'
 MOCKED_URL_REDIRECT = 'http+mock://requests-cache.com/redirect'
@@ -168,6 +169,12 @@ def get_mock_adapter() -> Adapter:
         MOCKED_URL,
         headers={'Content-Type': 'text/plain'},
         text='mock response',
+        status_code=200,
+    )
+    adapter.register_uri(
+        ANY_METHOD,
+        MOCKED_URL_ETAG,
+        headers={'ETag': ETAG},
         status_code=200,
     )
     adapter.register_uri(

--- a/tests/integration/base_storage_test.py
+++ b/tests/integration/base_storage_test.py
@@ -7,7 +7,6 @@ from requests_cache.backends import BaseStorage
 from tests.conftest import CACHE_NAME
 
 
-# TODO: Parameterize tests for all serializers?
 class BaseStorageTest:
     """Base class for testing cache storage dict-like interfaces"""
 

--- a/tests/unit/models/test_response.py
+++ b/tests/unit/models/test_response.py
@@ -75,7 +75,7 @@ def test_iterator(mock_session):
         last_request_chunks = chunks
 
 
-def test_revalidate__extend_expiration(mock_session):
+def test_reset_expiration__extend_expiration(mock_session):
     # Start with an expired response
     response = CachedResponse.from_response(
         mock_session.get(MOCKED_URL),
@@ -83,14 +83,14 @@ def test_revalidate__extend_expiration(mock_session):
     )
     assert response.is_expired is True
 
-    # Set expiration in the future and revalidate
-    is_expired = response.revalidate(datetime.utcnow() + timedelta(seconds=0.01))
+    # Set expiration in the future
+    is_expired = response.reset_expiration(datetime.utcnow() + timedelta(seconds=0.01))
     assert is_expired is response.is_expired is False
     sleep(0.1)
     assert response.is_expired is True
 
 
-def test_revalidate__shorten_expiration(mock_session):
+def test_reset_expiration__shorten_expiration(mock_session):
     # Start with a non-expired response
     response = CachedResponse.from_response(
         mock_session.get(MOCKED_URL),
@@ -98,8 +98,8 @@ def test_revalidate__shorten_expiration(mock_session):
     )
     assert response.is_expired is False
 
-    # Set expiration in the past and revalidate
-    is_expired = response.revalidate(datetime.utcnow() - timedelta(seconds=1))
+    # Set expiration in the past
+    is_expired = response.reset_expiration(datetime.utcnow() - timedelta(seconds=1))
     assert is_expired is response.is_expired is True
 
 

--- a/tests/unit/test_base_cache.py
+++ b/tests/unit/test_base_cache.py
@@ -1,0 +1,159 @@
+"""BaseCache tests that use mocked responses only"""
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+
+from requests_cache import CachedResponse
+from requests_cache.backends import BaseCache, SQLitePickleDict
+
+from tests.conftest import (
+    MOCKED_URL,
+    MOCKED_URL_HTTPS,
+    MOCKED_URL_JSON,
+    MOCKED_URL_REDIRECT,
+)
+
+YESTERDAY = datetime.utcnow() - timedelta(days=1)
+
+
+class TimeBomb:
+    """Class that will raise an error when unpickled"""
+
+    def __init__(self):
+        self.foo = 'bar'
+
+    def __setstate__(self, value):
+        raise ValueError('Invalid response!')
+
+
+def test_urls__with_invalid_response(mock_session):
+    responses = [mock_session.get(url) for url in [MOCKED_URL, MOCKED_URL_JSON, MOCKED_URL_HTTPS]]
+    responses[2] = AttributeError
+    with patch.object(SQLitePickleDict, '__getitem__', side_effect=responses):
+        expected_urls = [MOCKED_URL, MOCKED_URL_JSON]
+        assert set(mock_session.cache.urls) == set(expected_urls)
+
+    # The invalid response should be skipped, but remain in the cache for now
+    assert len(mock_session.cache.responses.keys()) == 3
+
+
+def test_keys(mock_session):
+    for url in [MOCKED_URL, MOCKED_URL_JSON, MOCKED_URL_REDIRECT]:
+        mock_session.get(url)
+
+    all_keys = set(mock_session.cache.responses.keys()) | set(mock_session.cache.redirects.keys())
+    assert set(mock_session.cache.keys()) == all_keys
+
+
+def test_update(mock_session):
+    src_cache = BaseCache()
+    for i in range(20):
+        src_cache.responses[f'key_{i}'] = f'value_{i}'
+        src_cache.redirects[f'key_{i}'] = f'value_{i}'
+
+    mock_session.cache.update(src_cache)
+    assert len(mock_session.cache.responses) == 20
+    assert len(mock_session.cache.redirects) == 20
+
+
+def test_values(mock_session):
+    for url in [MOCKED_URL, MOCKED_URL_JSON, MOCKED_URL_HTTPS]:
+        mock_session.get(url)
+
+    responses = list(mock_session.cache.values())
+    assert len(responses) == 3
+    assert all([isinstance(response, CachedResponse) for response in responses])
+
+
+@pytest.mark.parametrize('check_expiry, expected_count', [(True, 1), (False, 2)])
+def test_values__with_invalid_responses(check_expiry, expected_count, mock_session):
+    """values() should always exclude invalid responses, and optionally exclude expired responses"""
+    responses = [mock_session.get(url) for url in [MOCKED_URL, MOCKED_URL_JSON, MOCKED_URL_HTTPS]]
+    responses[1] = AttributeError
+    responses[2] = CachedResponse(expires=YESTERDAY, url='test')
+
+    with patch.object(SQLitePickleDict, '__getitem__', side_effect=responses):
+        values = mock_session.cache.values(check_expiry=check_expiry)
+        assert len(list(values)) == expected_count
+
+    # The invalid response should be skipped, but remain in the cache for now
+    assert len(mock_session.cache.responses.keys()) == 3
+
+
+@pytest.mark.parametrize('check_expiry, expected_count', [(True, 2), (False, 3)])
+def test_response_count(check_expiry, expected_count, mock_session):
+    """response_count() should always exclude invalid responses, and optionally exclude expired
+    and invalid responses"""
+    mock_session.get(MOCKED_URL)
+    mock_session.get(MOCKED_URL_JSON)
+
+    mock_session.cache.responses['expired_response'] = CachedResponse(expires=YESTERDAY)
+    mock_session.cache.responses['invalid_response'] = TimeBomb()
+    assert mock_session.cache.response_count(check_expiry=check_expiry) == expected_count
+
+
+def test_clear(mock_session):
+    mock_session.get(MOCKED_URL)
+    mock_session.get(MOCKED_URL_REDIRECT)
+    mock_session.cache.clear()
+    assert not mock_session.cache.has_url(MOCKED_URL)
+    assert not mock_session.cache.has_url(MOCKED_URL_REDIRECT)
+
+
+def test_has_url(mock_session):
+    mock_session.get(MOCKED_URL)
+    assert mock_session.cache.has_url(MOCKED_URL)
+    assert not mock_session.cache.has_url(MOCKED_URL_REDIRECT)
+
+
+def test_has_url__request_args(mock_session):
+    mock_session.get(MOCKED_URL, params={'foo': 'bar'})
+    assert mock_session.cache.has_url(MOCKED_URL, params={'foo': 'bar'})
+    assert not mock_session.cache.has_url(MOCKED_URL)
+
+
+def test_delete_url(mock_session):
+    mock_session.get(MOCKED_URL)
+    mock_session.cache.delete_url(MOCKED_URL)
+    assert not mock_session.cache.has_url(MOCKED_URL)
+
+
+def test_delete_url__request_args(mock_session):
+    mock_session.get(MOCKED_URL, params={'foo': 'bar'})
+    mock_session.cache.delete_url(MOCKED_URL, params={'foo': 'bar'})
+    assert not mock_session.cache.has_url(MOCKED_URL, params={'foo': 'bar'})
+
+
+def test_delete_url__nonexistent_response(mock_session):
+    """Deleting a response that was either already deleted (or never added) should fail silently"""
+    mock_session.cache.delete_url(MOCKED_URL)
+
+    mock_session.get(MOCKED_URL)
+    mock_session.cache.delete_url(MOCKED_URL)
+    assert not mock_session.cache.has_url(MOCKED_URL)
+    mock_session.cache.delete_url(MOCKED_URL)  # Should fail silently
+
+
+def test_delete_url__redirect(mock_session):
+    mock_session.get(MOCKED_URL_REDIRECT)
+    assert mock_session.cache.has_url(MOCKED_URL_REDIRECT)
+
+    mock_session.cache.delete_url(MOCKED_URL_REDIRECT)
+    assert not mock_session.cache.has_url(MOCKED_URL_REDIRECT)
+
+
+def test_delete_urls(mock_session):
+    urls = [MOCKED_URL, MOCKED_URL_JSON, MOCKED_URL_REDIRECT]
+    for url in urls:
+        mock_session.get(url)
+
+    mock_session.cache.delete_urls(urls)
+    for url in urls:
+        assert not mock_session.cache.has_url(MOCKED_URL_REDIRECT)
+
+
+def test_save_response_manual(mock_session):
+    response = mock_session.get(MOCKED_URL)
+    mock_session.cache.clear()
+    mock_session.cache.save_response(response)

--- a/tests/unit/test_base_cache.py
+++ b/tests/unit/test_base_cache.py
@@ -6,13 +6,7 @@ import pytest
 
 from requests_cache import CachedResponse
 from requests_cache.backends import BaseCache, SQLitePickleDict
-
-from tests.conftest import (
-    MOCKED_URL,
-    MOCKED_URL_HTTPS,
-    MOCKED_URL_JSON,
-    MOCKED_URL_REDIRECT,
-)
+from tests.conftest import MOCKED_URL, MOCKED_URL_HTTPS, MOCKED_URL_JSON, MOCKED_URL_REDIRECT
 
 YESTERDAY = datetime.utcnow() - timedelta(days=1)
 

--- a/tests/unit/test_cache_control.py
+++ b/tests/unit/test_cache_control.py
@@ -182,7 +182,7 @@ def test_update_from_cached_response(response_headers, expected_validation_heade
 
     actions.update_from_cached_response(cached_response)
     assert actions.validation_headers == expected_validation_headers
-    assert actions.revalidate is True
+    assert actions.revalidate is bool(expected_validation_headers)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -1,5 +1,4 @@
-"""CachedSession + BaseCache tests that use mocked responses only"""
-# TODO: This could be split up into some smaller test modules
+"""CachedSession tests that use mocked responses only"""
 import json
 import time
 from collections import UserDict, defaultdict
@@ -14,7 +13,7 @@ import requests
 from requests import Request, RequestException
 from requests.structures import CaseInsensitiveDict
 
-from requests_cache import ALL_METHODS, CachedResponse, CachedSession
+from requests_cache import ALL_METHODS, CachedSession
 from requests_cache._utils import get_placeholder_class
 from requests_cache.backends import BACKEND_CLASSES, BaseCache, SQLiteDict, SQLitePickleDict
 from requests_cache.backends.base import DESERIALIZE_ERRORS
@@ -27,8 +26,6 @@ from tests.conftest import (
     MOCKED_URL_REDIRECT,
     MOCKED_URL_REDIRECT_TARGET,
 )
-
-YESTERDAY = datetime.utcnow() - timedelta(days=1)
 
 
 def test_init_unregistered_backend():
@@ -50,6 +47,10 @@ def test_init_missing_backend_dependency():
 
 class MyCache(BaseCache):
     pass
+
+
+# Basic initialization
+# -----------------------------------------------------
 
 
 def test_init_backend_instance():
@@ -76,6 +77,44 @@ def test_init_backend_class():
     session = CachedSession('test_cache', backend=MyCache)
     assert isinstance(session.cache, MyCache)
     assert session.cache.cache_name == 'test_cache'
+
+
+def test_repr(mock_session):
+    """Test session and cache string representations"""
+    mock_session.expire_after = 11
+    mock_session.cache.responses['key'] = 'value'
+    mock_session.cache.redirects['key'] = 'value'
+    mock_session.cache.redirects['key_2'] = 'value'
+
+    assert mock_session.cache.cache_name in repr(mock_session) and '11' in repr(mock_session)
+    assert '2 redirects' in str(mock_session.cache) and '1 responses' in str(mock_session.cache)
+
+
+def test_response_defaults(mock_session):
+    """Both cached and new responses should always have the following attributes"""
+    mock_session.expire_after = datetime.utcnow() + timedelta(days=1)
+    response_1 = mock_session.get(MOCKED_URL)
+    response_2 = mock_session.get(MOCKED_URL)
+    response_3 = mock_session.get(MOCKED_URL)
+    cache_key = 'd7fa9fb7317b7412'
+
+    assert response_1.cache_key == cache_key
+    assert response_1.created_at is None
+    assert response_1.expires is None
+    assert response_1.from_cache is False
+    assert response_1.is_expired is False
+
+    assert isinstance(response_2.created_at, datetime)
+    assert isinstance(response_2.expires, datetime)
+    assert response_2.cache_key == cache_key
+    assert response_2.created_at == response_3.created_at
+    assert response_2.expires == response_3.expires
+    assert response_2.from_cache is response_3.from_cache is True
+    assert response_2.is_expired is response_3.is_expired is False
+
+
+# Main combinations of request methods and data fields
+# -----------------------------------------------------
 
 
 @pytest.mark.parametrize('method', ALL_METHODS)
@@ -125,6 +164,10 @@ def test_all_methods__ignored_parameters__redacted(field, method, mock_session):
     assert 'access_token' not in cached_response.request.body.decode('utf-8')
 
 
+# Variations of relevant request arguments
+# -----------------------------------------------------
+
+
 def test_params_positional_arg(mock_session):
     mock_session.request('GET', MOCKED_URL, {'param_1': 1})
     response = mock_session.request('GET', MOCKED_URL, {'param_1': 1})
@@ -158,17 +201,6 @@ def test_response_history(mock_session):
     assert len(mock_session.cache.redirects) == 1
 
 
-def test_repr(mock_session):
-    """Test session and cache string representations"""
-    mock_session.expire_after = 11
-    mock_session.cache.responses['key'] = 'value'
-    mock_session.cache.redirects['key'] = 'value'
-    mock_session.cache.redirects['key_2'] = 'value'
-
-    assert mock_session.cache.cache_name in repr(mock_session) and '11' in repr(mock_session)
-    assert '2 redirects' in str(mock_session.cache) and '1 responses' in str(mock_session.cache)
-
-
 def test_urls(mock_session):
     for url in [MOCKED_URL, MOCKED_URL_JSON, MOCKED_URL_HTTPS]:
         mock_session.get(url)
@@ -177,124 +209,8 @@ def test_urls(mock_session):
     assert set(mock_session.cache.urls) == set(expected_urls)
 
 
-def test_urls__with_invalid_response(mock_session):
-    responses = [mock_session.get(url) for url in [MOCKED_URL, MOCKED_URL_JSON, MOCKED_URL_HTTPS]]
-    responses[2] = AttributeError
-    with patch.object(SQLitePickleDict, '__getitem__', side_effect=responses):
-        expected_urls = [MOCKED_URL, MOCKED_URL_JSON]
-        assert set(mock_session.cache.urls) == set(expected_urls)
-
-    # The invalid response should be skipped, but remain in the cache for now
-    assert len(mock_session.cache.responses.keys()) == 3
-
-
-def test_keys(mock_session):
-    for url in [MOCKED_URL, MOCKED_URL_JSON, MOCKED_URL_REDIRECT]:
-        mock_session.get(url)
-
-    all_keys = set(mock_session.cache.responses.keys()) | set(mock_session.cache.redirects.keys())
-    assert set(mock_session.cache.keys()) == all_keys
-
-
-def test_update(mock_session):
-    src_cache = BaseCache()
-    for i in range(20):
-        src_cache.responses[f'key_{i}'] = f'value_{i}'
-        src_cache.redirects[f'key_{i}'] = f'value_{i}'
-
-    mock_session.cache.update(src_cache)
-    assert len(mock_session.cache.responses) == 20
-    assert len(mock_session.cache.redirects) == 20
-
-
-def test_values(mock_session):
-    for url in [MOCKED_URL, MOCKED_URL_JSON, MOCKED_URL_HTTPS]:
-        mock_session.get(url)
-
-    responses = list(mock_session.cache.values())
-    assert len(responses) == 3
-    assert all([isinstance(response, CachedResponse) for response in responses])
-
-
-@pytest.mark.parametrize('check_expiry, expected_count', [(True, 1), (False, 2)])
-def test_values__with_invalid_responses(check_expiry, expected_count, mock_session):
-    """values() should always exclude invalid responses, and optionally exclude expired responses"""
-    responses = [mock_session.get(url) for url in [MOCKED_URL, MOCKED_URL_JSON, MOCKED_URL_HTTPS]]
-    responses[1] = AttributeError
-    responses[2] = CachedResponse(expires=YESTERDAY, url='test')
-
-    with patch.object(SQLitePickleDict, '__getitem__', side_effect=responses):
-        values = mock_session.cache.values(check_expiry=check_expiry)
-        assert len(list(values)) == expected_count
-
-    # The invalid response should be skipped, but remain in the cache for now
-    assert len(mock_session.cache.responses.keys()) == 3
-
-
-class TimeBomb:
-    """Class that will raise an error when unpickled"""
-
-    def __init__(self):
-        self.foo = 'bar'
-
-    def __setstate__(self, value):
-        raise ValueError('Invalid response!')
-
-
-@pytest.mark.parametrize('check_expiry, expected_count', [(True, 2), (False, 3)])
-def test_response_count(check_expiry, expected_count, mock_session):
-    """response_count() should always exclude invalid responses, and optionally exclude expired responses"""
-    mock_session.get(MOCKED_URL)
-    mock_session.get(MOCKED_URL_JSON)
-
-    mock_session.cache.responses['expired_response'] = CachedResponse(expires=YESTERDAY)
-    mock_session.cache.responses['invalid_response'] = TimeBomb()
-    assert mock_session.cache.response_count(check_expiry=check_expiry) == expected_count
-
-
-def test_filter_fn(mock_session):
-    mock_session.filter_fn = lambda r: r.request.url != MOCKED_URL_JSON
-    mock_session.get(MOCKED_URL)
-    mock_session.get(MOCKED_URL_JSON)
-
-    assert mock_session.cache.has_url(MOCKED_URL)
-    assert not mock_session.cache.has_url(MOCKED_URL_JSON)
-
-
-def test_filter_fn__retroactive(mock_session):
-    """filter_fn should also apply to previously cached responses"""
-    mock_session.get(MOCKED_URL_JSON)
-    mock_session.filter_fn = lambda r: r.request.url != MOCKED_URL_JSON
-    mock_session.get(MOCKED_URL_JSON)
-
-    assert not mock_session.cache.has_url(MOCKED_URL_JSON)
-
-
-# def test_key_fn(mock_session):
-#     def create_key(request, **kwargs):
-#         """Create a key based on only the request URL (without params)"""
-#         return request.url.split('?')[0]
-
-#     mock_session.cache.key_fn = create_key
-#     mock_session.get(MOCKED_URL)
-#     response = mock_session.get(MOCKED_URL, params={'k': 'v'})
-#     assert response.from_cache is True
-
-
-def test_hooks(mock_session):
-    state = defaultdict(int)
-    mock_session.get(MOCKED_URL)
-
-    for hook in ('response',):
-
-        def hook_func(r, *args, **kwargs):
-            state[hook] += 1
-            assert r.from_cache is True
-            return r
-
-        for i in range(5):
-            mock_session.get(MOCKED_URL, hooks={hook: hook_func})
-        assert state[hook] == 5
+# Request matching
+# -----------------------------------------------------
 
 
 @pytest.mark.parametrize('method', ['POST', 'PUT'])
@@ -378,95 +294,6 @@ def test_normalize_params__url(mock_session):
     assert len(set(keys)) == 1
 
 
-def test_clear(mock_session):
-    mock_session.get(MOCKED_URL)
-    mock_session.get(MOCKED_URL_REDIRECT)
-    mock_session.cache.clear()
-    assert not mock_session.cache.has_url(MOCKED_URL)
-    assert not mock_session.cache.has_url(MOCKED_URL_REDIRECT)
-
-
-def test_has_url(mock_session):
-    mock_session.get(MOCKED_URL)
-    assert mock_session.cache.has_url(MOCKED_URL)
-    assert not mock_session.cache.has_url(MOCKED_URL_REDIRECT)
-
-
-def test_has_url__request_args(mock_session):
-    mock_session.get(MOCKED_URL, params={'foo': 'bar'})
-    assert mock_session.cache.has_url(MOCKED_URL, params={'foo': 'bar'})
-    assert not mock_session.cache.has_url(MOCKED_URL)
-
-
-def test_delete_url(mock_session):
-    mock_session.get(MOCKED_URL)
-    mock_session.cache.delete_url(MOCKED_URL)
-    assert not mock_session.cache.has_url(MOCKED_URL)
-
-
-def test_delete_url__request_args(mock_session):
-    mock_session.get(MOCKED_URL, params={'foo': 'bar'})
-    mock_session.cache.delete_url(MOCKED_URL, params={'foo': 'bar'})
-    assert not mock_session.cache.has_url(MOCKED_URL, params={'foo': 'bar'})
-
-
-def test_delete_url__nonexistent_response(mock_session):
-    """Deleting a response that was either already deleted (or never added) should fail silently"""
-    mock_session.cache.delete_url(MOCKED_URL)
-
-    mock_session.get(MOCKED_URL)
-    mock_session.cache.delete_url(MOCKED_URL)
-    assert not mock_session.cache.has_url(MOCKED_URL)
-    mock_session.cache.delete_url(MOCKED_URL)  # Should fail silently
-
-
-def test_delete_url__redirect(mock_session):
-    mock_session.get(MOCKED_URL_REDIRECT)
-    assert mock_session.cache.has_url(MOCKED_URL_REDIRECT)
-
-    mock_session.cache.delete_url(MOCKED_URL_REDIRECT)
-    assert not mock_session.cache.has_url(MOCKED_URL_REDIRECT)
-
-
-def test_delete_urls(mock_session):
-    urls = [MOCKED_URL, MOCKED_URL_JSON, MOCKED_URL_REDIRECT]
-    for url in urls:
-        mock_session.get(url)
-
-    mock_session.cache.delete_urls(urls)
-    for url in urls:
-        assert not mock_session.cache.has_url(MOCKED_URL_REDIRECT)
-
-
-def test_save_response_manual(mock_session):
-    response = mock_session.get(MOCKED_URL)
-    mock_session.cache.clear()
-    mock_session.cache.save_response(response)
-
-
-def test_response_defaults(mock_session):
-    """Both cached and new responses should always have the following attributes"""
-    mock_session.expire_after = datetime.utcnow() + timedelta(days=1)
-    response_1 = mock_session.get(MOCKED_URL)
-    response_2 = mock_session.get(MOCKED_URL)
-    response_3 = mock_session.get(MOCKED_URL)
-    cache_key = 'd7fa9fb7317b7412'
-
-    assert response_1.cache_key == cache_key
-    assert response_1.created_at is None
-    assert response_1.expires is None
-    assert response_1.from_cache is False
-    assert response_1.is_expired is False
-
-    assert isinstance(response_2.created_at, datetime)
-    assert isinstance(response_2.expires, datetime)
-    assert response_2.cache_key == cache_key
-    assert response_2.created_at == response_3.created_at
-    assert response_2.expires == response_3.expires
-    assert response_2.from_cache is response_3.from_cache is True
-    assert response_2.is_expired is response_3.is_expired is False
-
-
 def test_match_headers(mock_session):
     """With match_headers, requests with different headers should have different cache keys"""
     mock_session.cache.match_headers = True
@@ -507,6 +334,10 @@ def test_include_get_headers():
     """include_get_headers is aliased to match_headers for backwards-compatibility"""
     session = CachedSession(include_get_headers=True, backend='memory')
     assert session.cache.match_headers is True
+
+
+# Error handling
+# -----------------------------------------------------
 
 
 @pytest.mark.parametrize('exception_cls', DESERIALIZE_ERRORS)
@@ -579,6 +410,69 @@ def test_cache_disabled__nested(mock_session):
             for i in range(2):
                 assert mock_session.get(MOCKED_URL).from_cache is False
     assert mock_session.get(MOCKED_URL).from_cache is True
+
+
+def test_unpickle_errors(mock_session):
+    """If there is an error during deserialization, the request should be made again"""
+    assert mock_session.get(MOCKED_URL_JSON).from_cache is False
+
+    with patch.object(SQLitePickleDict, '__getitem__', side_effect=PickleError):
+        resp = mock_session.get(MOCKED_URL_JSON)
+        assert resp.from_cache is False
+        assert resp.json()['message'] == 'mock json response'
+
+    resp = mock_session.get(MOCKED_URL_JSON)
+    assert resp.from_cache is True
+    assert resp.json()['message'] == 'mock json response'
+
+
+# Additional CachedSession settings and methods
+# -----------------------------------------------------
+
+
+def test_filter_fn(mock_session):
+    mock_session.filter_fn = lambda r: r.request.url != MOCKED_URL_JSON
+    mock_session.get(MOCKED_URL)
+    mock_session.get(MOCKED_URL_JSON)
+
+    assert mock_session.cache.has_url(MOCKED_URL)
+    assert not mock_session.cache.has_url(MOCKED_URL_JSON)
+
+
+def test_filter_fn__retroactive(mock_session):
+    """filter_fn should also apply to previously cached responses"""
+    mock_session.get(MOCKED_URL_JSON)
+    mock_session.filter_fn = lambda r: r.request.url != MOCKED_URL_JSON
+    mock_session.get(MOCKED_URL_JSON)
+
+    assert not mock_session.cache.has_url(MOCKED_URL_JSON)
+
+
+def test_key_fn(mock_session):
+    def create_key(request, **kwargs):
+        """Create a key based on only the request URL (without params)"""
+        return request.url.split('?')[0]
+
+    mock_session.cache.key_fn = create_key
+    mock_session.get(MOCKED_URL)
+    response = mock_session.get(MOCKED_URL, params={'k': 'v'})
+    assert response.from_cache is True
+
+
+def test_hooks(mock_session):
+    state = defaultdict(int)
+    mock_session.get(MOCKED_URL)
+
+    for hook in ('response',):
+
+        def hook_func(r, *args, **kwargs):
+            state[hook] += 1
+            assert r.from_cache is True
+            return r
+
+        for i in range(5):
+            mock_session.get(MOCKED_URL, hooks={hook: hook_func})
+        assert state[hook] == 5
 
 
 def test_do_not_cache(mock_session):
@@ -724,7 +618,11 @@ def test_remove_expired_responses__per_request(mock_session):
     assert len(mock_session.cache.responses) == 1
 
 
-def test_per_request__enable_expiration(mock_session):
+# Additional request() and send() options
+# -----------------------------------------------------
+
+
+def test_request_expire_after__enable_expiration(mock_session):
     """No per-session expiration is set, but then overridden for a single request"""
     mock_session.expire_after = None
     response = mock_session.get(MOCKED_URL, expire_after=1)
@@ -736,7 +634,7 @@ def test_per_request__enable_expiration(mock_session):
     assert response.from_cache is False
 
 
-def test_per_request__disable_expiration(mock_session):
+def test_request_expire_after__disable_expiration(mock_session):
     """A per-session expiration is set, but then disabled for a single request"""
     mock_session.expire_after = 60
     response = mock_session.get(MOCKED_URL, expire_after=-1)
@@ -745,7 +643,7 @@ def test_per_request__disable_expiration(mock_session):
     assert response.expires is None
 
 
-def test_per_request__prepared_request(mock_session):
+def test_request_expire_after__prepared_request(mock_session):
     """The same should work for PreparedRequests with CachedSession.send()"""
     mock_session.expire_after = None
     request = Request(method='GET', url=MOCKED_URL, headers={}, data=None).prepare()
@@ -756,25 +654,3 @@ def test_per_request__prepared_request(mock_session):
     time.sleep(1)
     response = mock_session.get(MOCKED_URL)
     assert response.from_cache is False
-
-
-def test_per_request__no_expiration(mock_session):
-    """A per-session expiration is set, but then overridden with no per-request expiration"""
-    mock_session.expire_after = 1
-    response = mock_session.get(MOCKED_URL, expire_after=-1)
-    assert response.from_cache is False
-    assert response.expires is None
-
-
-def test_unpickle_errors(mock_session):
-    """If there is an error during deserialization, the request should be made again"""
-    assert mock_session.get(MOCKED_URL_JSON).from_cache is False
-
-    with patch.object(SQLitePickleDict, '__getitem__', side_effect=PickleError):
-        resp = mock_session.get(MOCKED_URL_JSON)
-        assert resp.from_cache is False
-        assert resp.json()['message'] == 'mock json response'
-
-    resp = mock_session.get(MOCKED_URL_JSON)
-    assert resp.from_cache is True
-    assert resp.json()['message'] == 'mock json response'

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -680,7 +680,7 @@ def test_remove_expired_responses__extend_expiration(mock_session):
     mock_session.expire_after = datetime.utcnow() - timedelta(seconds=0.01)
     mock_session.get(MOCKED_URL)
 
-    # Set expiration in the future and revalidate
+    # Set expiration in the future
     mock_session.remove_expired_responses(expire_after=datetime.utcnow() + timedelta(seconds=1))
     assert len(mock_session.cache.responses) == 1
     response = mock_session.get(MOCKED_URL)
@@ -692,7 +692,7 @@ def test_remove_expired_responses__shorten_expiration(mock_session):
     mock_session.expire_after = datetime.utcnow() + timedelta(seconds=1)
     mock_session.get(MOCKED_URL)
 
-    # Set expiration in the past and revalidate
+    # Set expiration in the past
     mock_session.remove_expired_responses(expire_after=datetime.utcnow() - timedelta(seconds=0.01))
     assert len(mock_session.cache.responses) == 0
     response = mock_session.get(MOCKED_URL)


### PR DESCRIPTION
Closes #541, closes #539, closes #546, closes #547

* Add `refresh` option to `CachedSession.request()` and `send()`
* Add `revalidate` option to `CachedSession.request()` and `send()`
* Revalidate for `Cache-Control: no-cache` request or response header
* Revalidate for `Cache-Control: max-age=0, must-revalidate` response headers
* Fix some incorrect wording about revalidation in docs