### PR TITLE
Add support for Cache-Control: only-if-cached and corresponding options for request() and send()

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,10 +4,12 @@
 [See all issues and PRs for 0.10](https://github.com/reclosedev/requests-cache/milestone/5?closed=1)
 
 **Expiration & Headers:**
-* Add `refresh` option to `CachedSession.request()` and `send()` to make (and cache) an new request regardless of existing cache contents
-* Add `revalidate` option to `CachedSession.request()` and `send()` to send conditional request (if possible) before using a cached response
+* Add support for `Cache-Control: only-if-cached`
 * Revalidate for `Cache-Control: no-cache` request or response header
 * Revalidate for `Cache-Control: max-age=0, must-revalidate` response headers
+* Add `only_if_cached` option to `CachedSession.request()` and `send()` to return only cached results without sending real requests
+* Add `refresh` option to `CachedSession.request()` and `send()` to make (and cache) an new request regardless of existing cache contents
+* Add `revalidate` option to `CachedSession.request()` and `send()` to send conditional request (if possible) before using a cached response
 
 ### 0.9.3 (2022-02-22)
 * Fix handling BSON serializer differences between pymongo's `bson` and standalone `bson` codec.

--- a/docs/user_guide/headers.md
+++ b/docs/user_guide/headers.md
@@ -11,6 +11,7 @@ requests-cache is not (yet) intended to be strict implementation of HTTP caching
 would like to see, please create an issue to request it.
 ```
 
+(conditional-requests)=
 ## Conditional Requests
 [Conditional requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Conditional_requests) are
 automatically sent for any servers that support them. Once a cached response expires, it will only
@@ -49,6 +50,8 @@ The following headers are currently supported:
 - `Cache-Control: max-age`: Used as the expiration time in seconds
 - `Cache-Control: no-cache`: Revalidate with the server before using a cached response
 - `Cache-Control: no-store`: Skip reading from and writing to the cache
+- `Cache-Control: only-if-cached`: Only return results from the cache. If not cached, return a 504
+  response instead of sending a new request. Note that this may return a stale response.
 - `If-None-Match`: Automatically added for revalidation, if an `ETag` is available
 - `If-Modified-Since`: Automatically added for revalidation, if `Last-Modified` is available
 


### PR DESCRIPTION
Closes #394
