### PR TITLE
Reorganize settings init logic

### DIFF
--- a/requests_cache/cache_control.py
+++ b/requests_cache/cache_control.py
@@ -27,7 +27,7 @@ from .expiration import (
     get_url_expiration,
 )
 from .models import CachedResponse
-from .settings import CacheSettings, RequestSettings
+from .settings import RequestSettings
 
 __all__ = ['CacheActions']
 
@@ -75,19 +75,15 @@ class CacheActions:
 
     @classmethod
     def from_request(
-        cls,
-        cache_key: str,
-        request: PreparedRequest,
-        settings: CacheSettings,
-        **kwargs,
+        cls, cache_key: str, request: PreparedRequest, settings: RequestSettings = None
     ):
         """Initialize from request info and cache settings"""
         request.headers = request.headers or CaseInsensitiveDict()
         directives = get_cache_directives(request.headers)
         logger.debug(f'Cache directives from request headers: {directives}')
 
-        # Merge session settings and request settings
-        settings = RequestSettings(settings, skip_invalid=True, **kwargs)
+        # Merge relevant headers with session + request settings
+        settings = settings or RequestSettings()
         settings.only_if_cached = settings.only_if_cached or 'only-if-cached' in directives
         settings.refresh = settings.refresh or bool(request.headers.pop(REFRESH_TEMP_HEADER, False))
         settings.revalidate = settings.revalidate or 'no-cache' in directives

--- a/tests/unit/test_cache_control.py
+++ b/tests/unit/test_cache_control.py
@@ -44,7 +44,7 @@ def test_init(
     get_url_expiration.return_value = url_expire_after
 
     settings = CacheSettings(cache_control=True, expire_after=1)
-    settings = RequestSettings(settings, expire_after=request_expire_after)
+    settings = RequestSettings.merge(settings, expire_after=request_expire_after)
     actions = CacheActions.from_request(
         cache_key='key',
         request=request,
@@ -121,7 +121,7 @@ def test_init_from_settings(url, request_expire_after, expected_expiration):
     if request_expire_after:
         request.headers = {'Cache-Control': f'max-age={request_expire_after}'}
 
-    actions = CacheActions.from_request('key', request, RequestSettings(settings))
+    actions = CacheActions.from_request('key', request, RequestSettings.merge(settings))
     assert actions.expire_after == expected_expiration
 
 
@@ -143,7 +143,7 @@ def test_init_from_settings_and_headers(
     """Test behavior with both cache settings and request headers."""
     request = get_mock_response(headers=headers)
     settings = CacheSettings(expire_after=expire_after)
-    actions = CacheActions.from_request('key', request, RequestSettings(settings))
+    actions = CacheActions.from_request('key', request, RequestSettings.merge(settings))
 
     assert actions.expire_after == expected_expiration
     assert actions.skip_read == expected_skip_read
@@ -284,7 +284,7 @@ def test_ignored_headers(directive):
     request.url = 'https://img.site.com/base/img.jpg'
     request.headers = {'Cache-Control': directive}
     settings = CacheSettings(expire_after=1, cache_control=True)
-    actions = CacheActions.from_request('key', request, RequestSettings(settings))
+    actions = CacheActions.from_request('key', request, RequestSettings.merge(settings))
 
     assert actions.expire_after == 1
     assert actions.skip_read is False


### PR DESCRIPTION
This just makes some implicit behavior a little more explicit and (hopefully) easier to follow. Also:
* Adds full type hints to extra kwargs for `CachedSession.send()`
* Fixes a bug in which some kwargs specific to requests-cache could get passed to `requests.Session.send()`