### PR TITLE
Revise behavior for refresh, force_refresh, and DO_NOT_CACHE

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.2.0
     hooks:
       - id: check-toml
       - id: check-yaml

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,15 +1,17 @@
 # History
 
-## 0.10.0 (Unreleased)
-[See all issues and PRs for 0.10](https://github.com/reclosedev/requests-cache/milestone/5?closed=1)
+## Unreleased
+[See all unreleased issues and PRs](https://github.com/reclosedev/requests-cache/milestone/5?closed=1)
 
 **Expiration & Headers:**
 * Add support for `Cache-Control: only-if-cached`
 * Revalidate for `Cache-Control: no-cache` request or response header
 * Revalidate for `Cache-Control: max-age=0, must-revalidate` response headers
 * Add `only_if_cached` option to `CachedSession.request()` and `send()` to return only cached results without sending real requests
-* Add `refresh` option to `CachedSession.request()` and `send()` to make (and cache) an new request regardless of existing cache contents
-* Add `revalidate` option to `CachedSession.request()` and `send()` to send conditional request (if possible) before using a cached response
+* Add `refresh` option to `CachedSession.request()` and `send()` to revalidate with the server before using a cached response
+* Add `force_refresh` option to `CachedSession.request()` and `send()` to awlays make and cache a new request regardless of existing cache contents
+* Make behavior for `expire_after=0` consistent with `Cache-Control: max-age=0`: if the response has a validator, save it to the cache but revalidate on use.
+* The constant `requests_cache.DO_NOT_CACHE` may be used to completely disable caching for a request
 
 **Backends:**
 * Add `wal` parameter for SQLite backend to enable write-ahead logging

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -26,6 +26,7 @@
   * `is_expired`
 * Populate `cache_key` and `expires` for new (non-cached) responses, if it was written to the cache
 * Add return type hints for all `CachedSession` request methods (`get()`, `post()`, etc.)
+* Always skip both cache read and write for requests excluded by `allowable_methods` (previously only skipped write)
 
 **Dependencies:**
 * Replace `appdirs` with `platformdirs`

--- a/docs/user_guide/filtering.md
+++ b/docs/user_guide/filtering.md
@@ -11,7 +11,7 @@ with a regular {py:class}`requests.Session` object, or wrapper functions like
 ```
 
 (http-methods)=
-## Cached HTTP Methods
+## Filter by HTTP Methods
 To cache additional HTTP methods, specify them with `allowable_methods`:
 ```python
 >>> session = CachedSession(allowable_methods=('GET', 'POST'))
@@ -22,7 +22,7 @@ For example, some APIs use the `POST` method to request data via a JSON-formatte
 requests that may exceed the max size of a `GET` request. You may also want to cache `POST` requests
 to ensure you don't send the exact same data multiple times.
 
-## Cached Status Codes
+## Filter by Status Codes
 To cache additional status codes, specify them with `allowable_codes`
 ```python
 >>> session = CachedSession(allowable_codes=(200, 418))
@@ -30,15 +30,14 @@ To cache additional status codes, specify them with `allowable_codes`
 ```
 
 (selective-caching)=
-## Cached URLs
+## Filter by URLs
 You can use {ref}`URL patterns <url-patterns>` to define an allowlist for selective caching, by
-using a expiration value of `0` (or `requests_cache.DO_NOT_CACHE`, to be more explicit) for
-non-matching request URLs:
+using a expiration value of `requests_cache.DO_NOT_CACHE` for non-matching request URLs:
 ```python
->>> from requests_cache import DO_NOT_CACHE, CachedSession
+>>> from requests_cache import DO_NOT_CACHE, NEVER_EXPIRE, CachedSession
 >>> urls_expire_after = {
 ...     '*.site_1.com': 30,
-...     'site_2.com/static': -1,
+...     'site_2.com/static': NEVER_EXPIRE,
 ...     '*': DO_NOT_CACHE,
 ... }
 >>> session = CachedSession(urls_expire_after=urls_expire_after)
@@ -51,6 +50,7 @@ expiration to `0`:
 >>> session = CachedSession(urls_expire_after=urls_expire_after, expire_after=0)
 ```
 
+(custom-filtering)=
 ## Custom Cache Filtering
 If you need more advanced behavior for choosing what to cache, you can provide a custom filtering
 function via the `filter_fn` param. This can by any function that takes a

--- a/examples/url_patterns.py
+++ b/examples/url_patterns.py
@@ -5,13 +5,13 @@ An example of {ref}`url-patterns`
 """
 from datetime import timedelta
 
-from requests_cache import CachedSession
+from requests_cache import DO_NOT_CACHE, NEVER_EXPIRE, CachedSession
 
 default_expire_after = 60 * 60               # By default, cached responses expire in an hour
 urls_expire_after = {
     'httpbin.org/image': timedelta(days=7),  # Requests for this base URL will expire in a week
-    '*.fillmurray.com': -1,                  # Requests matching this pattern will never expire
-    '*.placeholder.com/*': 0,                # Requests matching this pattern will not be cached
+    '*.fillmurray.com': NEVER_EXPIRE,        # Requests matching this pattern will never expire
+    '*.placeholder.com/*': DO_NOT_CACHE,     # Requests matching this pattern will not be cached
 }
 urls = [
     'https://httpbin.org/get',               # Will expire in an hour

--- a/requests_cache/__init__.py
+++ b/requests_cache/__init__.py
@@ -1,8 +1,6 @@
 # flake8: noqa: E402,F401
 from logging import getLogger
 
-logger = getLogger('requests_cache')
-
 # Version is defined in pyproject.toml.
 # It's copied here to make it easier for client code to check the installed version.
 __version__ = '0.10.0'
@@ -11,6 +9,7 @@ try:
     from .backends import *
     from .cache_control import *
     from .cache_keys import *
+    from .expiration import *
     from .models import *
     from .patcher import *
     from .serializers import *
@@ -18,4 +17,4 @@ try:
     from .settings import *
 # Log and ignore ImportErrors, if imported outside a virtualenv (e.g., just to check __version__)
 except ImportError as e:
-    logger.warning(e, exc_info=True)
+    getLogger('requests_cache').warning(e, exc_info=True)

--- a/requests_cache/backends/base.py
+++ b/requests_cache/backends/base.py
@@ -4,12 +4,14 @@
    :classes-only:
    :nosignatures:
 """
-import pickle
+from __future__ import annotations
+
 from abc import ABC
 from collections import UserDict
 from collections.abc import MutableMapping
 from datetime import datetime
 from logging import getLogger
+from pickle import PickleError
 from typing import Iterable, Iterator, Optional, Tuple, Union
 
 from requests import PreparedRequest, Response
@@ -21,7 +23,7 @@ from ..serializers import init_serializer
 from ..settings import DEFAULT_CACHE_NAME, CacheSettings
 
 # Specific exceptions that may be raised during deserialization
-DESERIALIZE_ERRORS = (AttributeError, ImportError, TypeError, ValueError, pickle.PickleError)
+DESERIALIZE_ERRORS = (AttributeError, ImportError, PickleError, TypeError, ValueError)
 
 ResponseOrKey = Union[CachedResponse, str]
 logger = getLogger(__name__)

--- a/requests_cache/cache_control.py
+++ b/requests_cache/cache_control.py
@@ -107,6 +107,7 @@ class CacheActions:
             or force_refresh
             or settings.disabled
             or expire_after == DO_NOT_CACHE
+            or str(request.method) not in settings.allowable_methods
         )
 
         actions = cls(

--- a/requests_cache/expiration.py
+++ b/requests_cache/expiration.py
@@ -10,7 +10,7 @@ from ._utils import try_int
 
 __all__ = ['DO_NOT_CACHE', 'EXPIRE_IMMEDIATELY', 'NEVER_EXPIRE', 'get_expiration_datetime']
 
-# May be set by either headers or expire_after param to disable caching or disable expiration
+# Special expiration values that may be set by either headers or keyword args
 EXPIRE_IMMEDIATELY = 0
 NEVER_EXPIRE = -1
 DO_NOT_CACHE = -2
@@ -23,8 +23,8 @@ logger = getLogger(__name__)
 
 def get_expiration_datetime(expire_after: ExpirationTime) -> Optional[datetime]:
     """Convert an expiration value in any supported format to an absolute datetime"""
-    # Never expire
-    if expire_after is None or expire_after == NEVER_EXPIRE:
+    # Never expire (or do not cache, in which case expiration won't be used)
+    if expire_after is None or expire_after in [NEVER_EXPIRE, DO_NOT_CACHE]:
         return None
     # Expire immediately
     elif try_int(expire_after) == EXPIRE_IMMEDIATELY:
@@ -43,6 +43,8 @@ def get_expiration_datetime(expire_after: ExpirationTime) -> Optional[datetime]:
 
 def get_expiration_seconds(expire_after: ExpirationTime) -> int:
     """Convert an expiration value in any supported format to an expiration time in seconds"""
+    if expire_after == DO_NOT_CACHE:
+        return DO_NOT_CACHE
     expires = get_expiration_datetime(expire_after)
     return ceil((expires - datetime.utcnow()).total_seconds()) if expires else NEVER_EXPIRE
 

--- a/requests_cache/expiration.py
+++ b/requests_cache/expiration.py
@@ -8,11 +8,12 @@ from typing import Dict, Optional, Union
 
 from ._utils import try_int
 
-__all__ = ['DO_NOT_CACHE', 'NEVER_EXPIRE', 'get_expiration_datetime']
+__all__ = ['DO_NOT_CACHE', 'EXPIRE_IMMEDIATELY', 'NEVER_EXPIRE', 'get_expiration_datetime']
 
 # May be set by either headers or expire_after param to disable caching or disable expiration
-DO_NOT_CACHE = 0
+EXPIRE_IMMEDIATELY = 0
 NEVER_EXPIRE = -1
+DO_NOT_CACHE = -2
 
 ExpirationTime = Union[None, int, float, str, datetime, timedelta]
 ExpirationPatterns = Dict[str, ExpirationTime]
@@ -26,7 +27,7 @@ def get_expiration_datetime(expire_after: ExpirationTime) -> Optional[datetime]:
     if expire_after is None or expire_after == NEVER_EXPIRE:
         return None
     # Expire immediately
-    elif try_int(expire_after) == DO_NOT_CACHE:
+    elif try_int(expire_after) == EXPIRE_IMMEDIATELY:
         return datetime.utcnow()
     # Already a datetime or datetime str
     if isinstance(expire_after, str):

--- a/requests_cache/expiration.py
+++ b/requests_cache/expiration.py
@@ -11,9 +11,9 @@ from ._utils import try_int
 __all__ = ['DO_NOT_CACHE', 'EXPIRE_IMMEDIATELY', 'NEVER_EXPIRE', 'get_expiration_datetime']
 
 # Special expiration values that may be set by either headers or keyword args
+DO_NOT_CACHE = 0x0D0E0200020704  # Per RFC 4824
 EXPIRE_IMMEDIATELY = 0
 NEVER_EXPIRE = -1
-DO_NOT_CACHE = -2
 
 ExpirationTime = Union[None, int, float, str, datetime, timedelta]
 ExpirationPatterns = Dict[str, ExpirationTime]

--- a/requests_cache/settings.py
+++ b/requests_cache/settings.py
@@ -1,6 +1,6 @@
 from typing import Callable, Dict, Iterable, Union
 
-from attr import asdict, define, field
+from attr import define, field
 from requests import Response
 
 from ._utils import get_valid_kwargs
@@ -16,15 +16,12 @@ FilterCallback = Callable[[Response], bool]
 KeyCallback = Callable[..., str]
 
 
-@define(init=False)
+@define
 class CacheSettings:
     """Class used internally to store settings that affect caching behavior. This allows settings
     to be used across multiple modules, but exposed to the user in a single property
     (:py:attr:`.CachedSession.settings`). These values can safely be modified after initialization. See
     :py:class:`.CachedSession` and :ref:`user-guide` for usage details.
-
-    Args:
-        skip_invalid: Ignore invalid settings for easier initialization from mixed ``**kwargs``
     """
 
     allowable_codes: Iterable[int] = field(default=DEFAULT_STATUS_CODES)
@@ -40,34 +37,21 @@ class CacheSettings:
     stale_if_error: bool = field(default=False)
     urls_expire_after: Dict[str, ExpirationTime] = field(factory=dict)
 
-    def __init__(self, **kwargs):
-        kwargs = self._rename_kwargs(kwargs)
-        if kwargs.pop('skip_invalid', False) is True:
-            kwargs = get_valid_kwargs(self.__attrs_init__, kwargs)
-        self.__attrs_init__(**kwargs)
+    @classmethod
+    def from_kwargs(cls, **kwargs):
+        """Constructor with some additional steps:
+
+        * Handle some deprecated argument names
+        * Ignore invalid settings, for easier initialization from mixed ``**kwargs``
+        """
+        kwargs = cls._rename_kwargs(kwargs)
+        kwargs = get_valid_kwargs(cls.__init__, kwargs)
+        return cls(**kwargs)
 
     @staticmethod
     def _rename_kwargs(kwargs):
-        """Handle some deprecated argument names"""
         if 'old_data_on_error' in kwargs:
             kwargs['stale_if_error'] = kwargs.pop('old_data_on_error')
         if 'include_get_headers' in kwargs:
             kwargs['match_headers'] = kwargs.pop('include_get_headers')
         return kwargs
-
-
-@define(init=False)
-class RequestSettings(CacheSettings):
-    """Cache settings that may be set for an individual request"""
-
-    # Additional settings that may be set for an individual request; not used at session level
-    refresh: bool = field(default=False)
-    revalidate: bool = field(default=False)
-    request_expire_after: ExpirationTime = field(default=None)
-
-    def __init__(self, session_settings: CacheSettings = None, **kwargs):
-        """Start with session-level cache settings and append/override with request-level settings"""
-        session_kwargs = asdict(session_settings) if session_settings else {}
-        # request-level expiration needs to be stored separately
-        kwargs['request_expire_after'] = kwargs.pop('expire_after', None)
-        super().__init__(**{**session_kwargs, **kwargs})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ import pytest
 import requests
 from requests_mock import ANY as ANY_METHOD
 from requests_mock import Adapter
+from rich.logging import RichHandler
 from timeout_decorator import timeout
 
 from requests_cache import ALL_METHODS, CachedSession, install_cache, uninstall_cache
@@ -77,7 +78,12 @@ AWS_OPTIONS = {
 
 
 # Configure logging to show log output when tests fail (or with pytest -s)
-basicConfig(level='INFO')
+basicConfig(
+    level='INFO',
+    format='%(message)s',
+    datefmt='[%m-%d %H:%M:%S]',
+    handlers=[RichHandler(rich_tracebacks=True, markup=True)],
+)
 # getLogger('requests_cache').setLevel('DEBUG')
 logger = getLogger(__name__)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,6 +63,7 @@ MOCKED_URL_JSON = 'http+mock://requests-cache.com/json'
 MOCKED_URL_REDIRECT = 'http+mock://requests-cache.com/redirect'
 MOCKED_URL_REDIRECT_TARGET = 'http+mock://requests-cache.com/redirect_target'
 MOCKED_URL_404 = 'http+mock://requests-cache.com/nonexistent'
+MOCKED_URL_500 = 'http+mock://requests-cache.com/answer?q=this-statement-is-false'
 MOCK_PROTOCOLS = ['mock://', 'http+mock://', 'https+mock://']
 
 PROJECT_DIR = abspath(dirname(dirname(__file__)))
@@ -212,11 +213,8 @@ def get_mock_adapter() -> Adapter:
         text='mock redirected response',
         status_code=200,
     )
-    adapter.register_uri(
-        ANY_METHOD,
-        MOCKED_URL_404,
-        status_code=404,
-    )
+    adapter.register_uri(ANY_METHOD, MOCKED_URL_404, status_code=404)
+    adapter.register_uri(ANY_METHOD, MOCKED_URL_500, status_code=500)
     return adapter
 
 

--- a/tests/unit/test_cache_control.py
+++ b/tests/unit/test_cache_control.py
@@ -44,12 +44,7 @@ def test_init(
     get_url_expiration.return_value = url_expire_after
 
     settings = CacheSettings(cache_control=True, expire_after=1)
-    actions = CacheActions.from_request(
-        cache_key='key',
-        request=request,
-        settings=settings,
-        request_expire_after=request_expire_after,
-    )
+    actions = CacheActions.from_request(cache_key='key', request=request, settings=settings)
     assert actions.expire_after == expected_expiration
 
 
@@ -83,7 +78,7 @@ def test_init_from_headers__no_store():
     )
 
     assert actions.skip_read is True
-    assert actions._no_store is True
+    assert actions.skip_write is True
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_expiration.py
+++ b/tests/unit/test_expiration.py
@@ -3,7 +3,11 @@ from unittest.mock import patch
 
 import pytest
 
-from requests_cache.expiration import DO_NOT_CACHE, get_expiration_datetime, get_url_expiration
+from requests_cache.expiration import (
+    EXPIRE_IMMEDIATELY,
+    get_expiration_datetime,
+    get_url_expiration,
+)
 from tests.conftest import HTTPDATE_DATETIME, HTTPDATE_STR
 
 
@@ -11,7 +15,7 @@ from tests.conftest import HTTPDATE_DATETIME, HTTPDATE_STR
 def test_get_expiration_datetime__no_expiration(mock_datetime):
     assert get_expiration_datetime(None) is None
     assert get_expiration_datetime(-1) is None
-    assert get_expiration_datetime(DO_NOT_CACHE) == mock_datetime.utcnow()
+    assert get_expiration_datetime(EXPIRE_IMMEDIATELY) == mock_datetime.utcnow()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_patcher.py
+++ b/tests/unit/test_patcher.py
@@ -73,6 +73,14 @@ def test_enabled(cached_request, original_request, tempfile_path):
     assert original_request.call_count == 0
 
 
+def test_is_installed():
+    assert requests_cache.is_installed() is False
+    requests_cache.install_cache(name=CACHE_NAME, use_temp=True)
+    assert requests_cache.is_installed() is True
+    requests_cache.uninstall_cache()
+    assert requests_cache.is_installed() is False
+
+
 @patch.object(BaseCache, 'remove_expired_responses')
 def test_remove_expired_responses(remove_expired_responses, tempfile_path):
     requests_cache.install_cache(tempfile_path, expire_after=360)


### PR DESCRIPTION
More refactoring of cache settings and policy logic, continuing from #555.

* Fix a bug in which some kwargs specific to requests-cache could get passed to `requests.Session.send()`
* Rename two (unreleased) options to be more consistent with browser behavior:
    * `revalidate()` -> `refresh()`
    * `refresh()` -> `force_refresh()`
* Revert `RequestSettings` changes and use just kwargs instead for per-request settings
* Add full type hints back to extra kwargs for `CachedSession.send()`
* Use 'must-revalidate' as a temporary header for a user-requested refresh
* Use expiration value of 0 more accurately as 'expire immediately' rather than 'do not cache'
    * Behavior is now the same as `Cache-Control: max-age=0`
    * It may potentially be saved and used with revalidation, depending on other headers/settings
* `DO_NOT_CACHE` now has a different value but same effect: always skip the cache on both read and write
* Refer to constants in docs instead of magic numbers
* Log more details about post-read and pre-cache checks
* Also skip cache read for requests excluded by `allowable_methods` (previously only skipped write)