### PR TITLE
Improve performance for cache eviction in SQLite backend

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,7 +14,9 @@
 * The constant `requests_cache.DO_NOT_CACHE` may be used to completely disable caching for a request
 
 **Backends:**
-* SQLite: Add a `wal` parameter to enable write-ahead logging
+* SQLite: Improve performance for removing expired items
+* SQLite: Add `sorted()` method with sorting and other query options
+* SQLite: Add `wal` parameter to enable write-ahead logging
 
 **Other features:**
 * All settings that affect cache behavior can now be accessed and modified via `CachedSession.settings`

--- a/examples/generate_test_db.py
+++ b/examples/generate_test_db.py
@@ -16,9 +16,12 @@ from requests_cache import ALL_METHODS, CachedResponse, CachedSession
 from requests_cache.models.response import format_file_size
 from tests.conftest import HTTPBIN_FORMATS, HTTPBIN_METHODS
 
-# TODO: If others would find it useful, these settings could be turned into CLI args
 BACKEND = 'sqlite'
 CACHE_NAME = 'rubbish_bin'
+MAX_EXPIRE_AFTER = 30  # In seconds; set to -1 to disable expiration
+MAX_RESPONSE_SIZE = 10000  # In bytes
+N_RESPONSES = 100000
+N_INVALID_RESPONSES = 10
 
 BASE_RESPONSE = requests.get('https://httpbin.org/get')
 HTTPBIN_EXTRA_ENDPOINTS = [
@@ -28,11 +31,6 @@ HTTPBIN_EXTRA_ENDPOINTS = [
     'redirect/5',
     'stream-bytes/1024',
 ]
-MAX_EXPIRE_AFTER = 30  # In seconds; set to -1 to disable expiration
-MAX_RESPONSE_SIZE = 10000  # In bytes
-N_RESPONSES = 100000
-N_INVALID_RESPONSES = 10
-
 logging.basicConfig(level='INFO')
 logger = logging.getLogger('requests_cache')
 

--- a/requests_cache/backends/sqlite.py
+++ b/requests_cache/backends/sqlite.py
@@ -146,25 +146,16 @@ class SQLiteCache(BaseCache):
             self.remove_invalid_redirects()
 
     def remove_invalid_redirects(self):
-        # TODO: Benchmark these 2 statements
         with self.redirects.connection(commit=True) as conn:
             t1 = self.redirects.table_name
             t2 = self.responses.table_name
-            # Option 1
-            stmt = (
-                f'DELETE FROM {t1} WHERE NOT EXISTS '
-                f'    (SELECT * FROM {t2} WHERE {t1}.key = {t2}.value)'
-            )
-
-            # Option 2
-            stmt = (
+            conn.execute(
                 f'DELETE FROM {t1} WHERE key IN ('
                 f'    SELECT {t1}.key FROM {t1}'
                 f'    LEFT JOIN {t2} ON {t2}.key = {t1}.value'
                 f'    WHERE {t2}.key IS NULL'
                 ')'
             )
-            conn.execute(stmt)
 
 
 class SQLiteDict(BaseStorage):

--- a/tests/integration/test_sqlite.py
+++ b/tests/integration/test_sqlite.py
@@ -1,4 +1,5 @@
 import os
+from datetime import datetime, timedelta
 from os.path import join
 from tempfile import NamedTemporaryFile, gettempdir
 from threading import Thread
@@ -9,6 +10,7 @@ from platformdirs import user_cache_dir
 
 from requests_cache.backends.base import BaseCache
 from requests_cache.backends.sqlite import MEMORY_URI, SQLiteCache, SQLiteDict, SQLitePickleDict
+from requests_cache.models.response import CachedResponse
 from tests.integration.base_cache_test import BaseCacheTest
 from tests.integration.base_storage_test import CACHE_NAME, BaseStorageTest
 
@@ -117,7 +119,6 @@ class SQLiteTestCase(BaseStorageTest):
 
     def test_switch_commit(self):
         cache = self.init_cache()
-        cache.clear()
         cache['key_1'] = 'value_1'
         cache = self.init_cache(clear=False)
         assert 'key_1' in cache
@@ -135,13 +136,47 @@ class SQLiteTestCase(BaseStorageTest):
         cache_1 = self.init_cache(1, **kwargs)
         cache_2 = self.init_cache(2, **kwargs)
 
-        n = 1000
+        n = 500
         for i in range(n):
             cache_1[f'key_{i}'] = f'value_{i}'
             cache_2[f'key_{i*2}'] = f'value_{i}'
 
         assert set(cache_1.keys()) == {f'key_{i}' for i in range(n)}
         assert set(cache_2.values()) == {f'value_{i}' for i in range(n)}
+
+    @pytest.mark.parametrize('limit', [None, 50])
+    def test_sorted__by_size(self, limit):
+        cache = self.init_cache()
+
+        # Insert items with decreasing size
+        for i in range(100):
+            suffix = 'padding' * (100 - i)
+            cache[f'key_{i}'] = f'value_{i}_{suffix}'
+
+        # Sorted items should be in ascending order by size
+        items = list(cache.sorted(key='size'))
+        assert len(items) == limit or 100
+
+        prev_item = None
+        for i, item in enumerate(items):
+            assert prev_item is None or len(prev_item) > len(item)
+
+    def test_sorted__reversed(self):
+        cache = self.init_cache()
+
+        for i in range(100):
+            cache[f'key_{i+1:03}'] = f'value_{i+1}'
+
+        items = list(cache.sorted(key='key', reversed=True))
+        assert len(items) == 100
+        for i, item in enumerate(items):
+            assert item == f'value_{100-i}'
+
+    def test_sorted__invalid_sort_key(self):
+        cache = self.init_cache()
+        cache['key_1'] = 'value_1'
+        with pytest.raises(ValueError):
+            list(cache.sorted(key='invalid_key'))
 
 
 class TestSQLiteDict(SQLiteTestCase):
@@ -151,6 +186,46 @@ class TestSQLiteDict(SQLiteTestCase):
 class TestSQLitePickleDict(SQLiteTestCase):
     storage_class = SQLitePickleDict
     picklable = True
+
+    @pytest.mark.parametrize('limit', [None, 50])
+    def test_sorted__by_expires(self, limit):
+        cache = self.init_cache()
+        now = datetime.utcnow()
+
+        # Insert items with decreasing expiration time
+        for i in range(100):
+            response = CachedResponse(expires=now + timedelta(seconds=101 - i))
+            cache[f'key_{i}'] = response
+
+        # Sorted items should be in ascending order by expiration time
+        items = list(cache.sorted(key='expires'))
+        assert len(items) == limit or 100
+
+        prev_item = None
+        for i, item in enumerate(items):
+            assert prev_item is None or prev_item.expires < item.expires
+
+    def test_sorted__exclude_expired(self):
+        cache = self.init_cache()
+        now = datetime.utcnow()
+
+        # Make only odd numbered items expired
+        for i in range(100):
+            delta = 101 - i
+            if i % 2 == 1:
+                delta -= 100
+
+            response = CachedResponse(status_code=i, expires=now + timedelta(seconds=delta))
+            cache[f'key_{i}'] = response
+
+        # Items should only include unexpired (even numbered) items, and still be in sorted order
+        items = list(cache.sorted(key='expires', exclude_expired=True))
+        assert len(items) == 50
+        prev_item = None
+
+        for i, item in enumerate(items):
+            assert prev_item is None or prev_item.expires < item.expires
+            assert item.status_code % 2 == 0
 
 
 class TestSQLiteCache(BaseCacheTest):
@@ -190,3 +265,28 @@ class TestSQLiteCache(BaseCacheTest):
         """
         session = self.init_session()
         assert session.cache.db_path == session.cache.responses.db_path
+
+    def test_sorted(self):
+        """Test wrapper method for SQLiteDict.sorted(), with all arguments combined"""
+        session = self.init_session(clear=False)
+        now = datetime.utcnow()
+
+        # Insert items with decreasing expiration time
+        for i in range(500):
+            delta = 1000 - i
+            if i > 400:
+                delta -= 2000
+
+            response = CachedResponse(status_code=i, expires=now + timedelta(seconds=delta))
+            session.cache.responses[f'key_{i}'] = response
+
+        # Sorted items should be in ascending order by expiration time
+        items = list(
+            session.cache.sorted(key='expires', exclude_expired=True, reversed=True, limit=100)
+        )
+        assert len(items) == 100
+
+        prev_item = None
+        for i, item in enumerate(items):
+            assert prev_item is None or prev_item.expires < item.expires
+            assert not item.is_expired

--- a/tests/unit/test_patcher.py
+++ b/tests/unit/test_patcher.py
@@ -82,8 +82,8 @@ def test_is_installed():
 
 
 @patch.object(BaseCache, 'remove_expired_responses')
-def test_remove_expired_responses(remove_expired_responses, tempfile_path):
-    requests_cache.install_cache(tempfile_path, expire_after=360)
+def test_remove_expired_responses(remove_expired_responses):
+    requests_cache.install_cache(backend='memory', expire_after=360)
     requests_cache.remove_expired_responses()
     assert remove_expired_responses.called is True
     requests_cache.uninstall_cache()
@@ -93,9 +93,3 @@ def test_remove_expired_responses(remove_expired_responses, tempfile_path):
 def test_remove_expired_responses__cache_not_installed(remove_expired_responses):
     requests_cache.remove_expired_responses()
     assert remove_expired_responses.called is False
-
-
-@patch.object(BaseCache, 'remove_expired_responses')
-def test_remove_expired_responses__no_expiration(remove_expired_responses, installed_session):
-    requests_cache.remove_expired_responses()
-    assert remove_expired_responses.called is True


### PR DESCRIPTION
Closes #364

**Note:** There may still be more improvements to make here, so this will likely change somewhat before release.

This adds a significantly more efficient implementation of `remove_expired_responses()` for SQLite. This does modify the table structure (new column + index), but retains backward-compatibility by updating tables created in previous versions of requests-cache.

Based on some quick benchmarks, this appears to result in a speedup of over 10x.

This also adds a `sorted()` method for the SQLite backend, which allows sorting responses by size or expiration. Also allows a query limit, reverse order, and excluding expired responses.