### PR TITLE
Close database connections on contextmanager exit or session.close() 

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -21,21 +21,26 @@
 * MongoDB:
   * Store responses in plain (human-readable) document format instead of fully serialized binary
   * Add optional integration with MongoDB TTL to improve performance for removing expired responses
+* SQLite, Redis, MongoDB, and GridFS: Close open database connections when `CachedSession` is used as a contextmanager, or if `CachedSession.close()` is called
 
-**Other features:**
-* All settings that affect cache behavior can now be accessed and modified via `CachedSession.settings`
-* Add `OriginalResponse` class, which wraps `requests.Response` objects and adds type hints for extra cache attributes set on non-cached responses:
+**Type hints:**
+* Add `OriginalResponse` type, which adds type hints to `requests.Response` objects for extra attributes added by requests-cache:
   * `cache_key`
   * `created_at`
   * `expires`
   * `from_cache`
   * `is_expired`
-* Populate `cache_key` and `expires` for new (non-cached) responses, if it was written to the cache
+* `OriginalResponse.cache_key` and `expires` will be populated for any new response that was written to the cache
+* Add return type hints for all request wrapper methods (`CachedSession.get()`, `head()`, etc.)
+
+**Request Matching & Filtering:**
 * Add serializer name to cache keys to avoid errors due to switching serializers
-* Add return type hints for all `CachedSession` request methods (`get()`, `post()`, etc.)
 * Always skip both cache read and write for requests excluded by `allowable_methods` (previously only skipped write)
 * Ignore and redact common authentication params and headers (e.g., for OAuth2) by default
   * This is simply a default value for `ignored_parameters`, to avoid accidentally storing credentials in the cache
+
+**Other features:**
+* All settings that affect cache behavior can now be accessed and modified via `CachedSession.settings`
 
 **Dependencies:**
 * Replace `appdirs` with `platformdirs`

--- a/requests_cache/backends/base.py
+++ b/requests_cache/backends/base.py
@@ -100,6 +100,12 @@ class BaseCache:
         self.responses.clear()
         self.redirects.clear()
 
+    def close(self):
+        """Close any open backend connections"""
+        logger.debug('Closing backend connections')
+        self.responses.close()
+        self.redirects.close()
+
     def create_key(self, request: PreparedRequest = None, **kwargs) -> str:
         """Create a normalized cache key from a request object"""
         key_fn = self._settings.key_fn or create_key
@@ -271,6 +277,9 @@ class BaseStorage(MutableMapping, ABC):
                 del self[k]
             except KeyError:
                 pass
+
+    def close(self):
+        """Close any open backend connections"""
 
     def __str__(self):
         return str(list(self.keys()))

--- a/requests_cache/backends/mongodb.py
+++ b/requests_cache/backends/mongodb.py
@@ -136,6 +136,9 @@ class MongoDict(BaseStorage):
     def clear(self):
         self.collection.drop()
 
+    def close(self):
+        self.connection.close()
+
 
 class MongoPickleDict(MongoDict):
     """Same as :class:`MongoDict`, but serializes values before saving.

--- a/requests_cache/backends/redis.py
+++ b/requests_cache/backends/redis.py
@@ -102,6 +102,9 @@ class RedisDict(BaseStorage):
     def clear(self):
         self.bulk_delete(self.keys())
 
+    def close(self):
+        self.connection.close()
+
     def keys(self):
         return [
             decode(key).replace(f'{self.namespace}:', '')

--- a/requests_cache/session.py
+++ b/requests_cache/session.py
@@ -96,9 +96,9 @@ class CacheMixin(MIXIN_BASE):
         self.settings.expire_after = value
 
     # Wrapper methods to add return type hints
-    def get(self, url: str, **kwargs) -> AnyResponse:  # type: ignore
+    def get(self, url: str, params=None, **kwargs) -> AnyResponse:  # type: ignore
         kwargs.setdefault('allow_redirects', True)
-        return self.request('GET', url, **kwargs)
+        return self.request('GET', url, params=params, **kwargs)
 
     def options(self, url: str, **kwargs) -> AnyResponse:  # type: ignore
         kwargs.setdefault('allow_redirects', True)
@@ -108,14 +108,14 @@ class CacheMixin(MIXIN_BASE):
         kwargs.setdefault('allow_redirects', False)
         return self.request('HEAD', url, **kwargs)
 
-    def post(self, url: str, **kwargs) -> AnyResponse:  # type: ignore
-        return self.request('POST', url, **kwargs)
+    def post(self, url: str, data=None, **kwargs) -> AnyResponse:  # type: ignore
+        return self.request('POST', url, data=data, **kwargs)
 
-    def put(self, url: str, **kwargs) -> AnyResponse:  # type: ignore
-        return self.request('PUT', url, **kwargs)
+    def put(self, url: str, data=None, **kwargs) -> AnyResponse:  # type: ignore
+        return self.request('PUT', url, data=data, **kwargs)
 
-    def patch(self, url: str, **kwargs) -> AnyResponse:  # type: ignore
-        return self.request('PATCH', url, **kwargs)
+    def patch(self, url: str, data=None, **kwargs) -> AnyResponse:  # type: ignore
+        return self.request('PATCH', url, data=data, **kwargs)
 
     def delete(self, url: str, **kwargs) -> AnyResponse:  # type: ignore
         return self.request('DELETE', url, **kwargs)

--- a/requests_cache/session.py
+++ b/requests_cache/session.py
@@ -292,6 +292,11 @@ class CacheMixin(MIXIN_BASE):
             finally:
                 self.settings.disabled = False
 
+    def close(self):
+        """Close the session and any open backend connections"""
+        super().close()
+        self.cache.close()
+
     def remove_expired_responses(self, expire_after: ExpirationTime = None):
         """Remove expired responses from the cache, optionally with revalidation
 

--- a/tests/integration/base_cache_test.py
+++ b/tests/integration/base_cache_test.py
@@ -71,7 +71,8 @@ class BaseCacheTest:
 
     @classmethod
     def teardown_class(cls):
-        cls().init_session(clear=True)
+        session = cls().init_session(clear=True)
+        session.close()
 
     @pytest.mark.parametrize('serializer', TEST_SERIALIZERS.values())
     @pytest.mark.parametrize('method', HTTPBIN_METHODS)


### PR DESCRIPTION
Closes #588

Applies to:
* SQLite
* MongoDB/GridFS
* Redis