### PR TITLE
Merge serializer-specific storage classes into respective parent classes

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -23,6 +23,7 @@
 **Backends:**
 * SQLite:
   * Improve performance for removing expired items
+  * Add `size()` method to get estimated size of the database (including in-memory databases)
   * Add `sorted()` method with sorting and other query options
   * Add `wal` parameter to enable write-ahead logging
 * MongoDB:
@@ -33,7 +34,14 @@
   * Create default table in on-demand mode instead of provisioned
   * Add optional integration with DynamoDB TTL to improve performance for removing expired responses
     * This is enabled by default, but may be disabled
+* Filesystem:
+  * The default file format has been changed from pickle to JSON
 * SQLite, Redis, MongoDB, and GridFS: Close open database connections when `CachedSession` is used as a contextmanager, or if `CachedSession.close()` is called
+
+**Request Matching & Filtering:**
+* Add serializer name to cache keys to avoid errors due to switching serializers
+* Always skip both cache read and write for requests excluded by `allowable_methods` (previously only skipped write)
+* Ignore and redact common authentication headers and request parameters by default. This provides some default recommended values for `ignored_parameters`, to avoid accidentally storing common credentials (e.g., OAuth tokens) in the cache. This will have no effect if you are already setting `ignored_parameters`.
 
 **Type hints:**
 * Add `OriginalResponse` type, which adds type hints to `requests.Response` objects for extra attributes added by requests-cache:
@@ -45,27 +53,26 @@
 * `OriginalResponse.cache_key` and `expires` will be populated for any new response that was written to the cache
 * Add request wrapper methods with return type hints for all HTTP methods (`CachedSession.get()`, `head()`, etc.)
 
-**Request Matching & Filtering:**
-* Add serializer name to cache keys to avoid errors due to switching serializers
-* Always skip both cache read and write for requests excluded by `allowable_methods` (previously only skipped write)
-* Ignore and redact common authentication params and headers (e.g., for OAuth2) by default
-  * This is simply a default value for `ignored_parameters`, to avoid accidentally storing credentials in the cache
-
 **Dependencies:**
 * Replace `appdirs` with `platformdirs`
 
-**Potentially breaking changes:**
-The following undocumented behaviors have been removed:
-* The arguments `match_headers` and `ignored_parameters` must be passed to `CachedSession`.
-  * Previously, these could also be passed to a `BaseCache` instance.
-* The `CachedSession` `backend` argument must be either an instance or string alias.
-  * Previously it would also accept a backend class.
-* After initialization, cache settings can only be accesed and modified via
-  `CachedSession.settings`.
-  * Previously, some settings could be modified by setting them on either `CachedSession` or `BaseCache`. In some cases this could silently fail or otherwise have undefined behavior.
+**Breaking changes:**
+Some relatively minor breaking changes have been made that are not expected to affect most users.
+If you encounter a problem not listed here after updating, please file a bug report!
 
-Internal module changes:
-* The contents of the `cache_control` module have been split up into multiple modules in a new `policy` subpackage
+The following undocumented behaviors have been removed:
+* The arguments `match_headers` and `ignored_parameters` must be passed to `CachedSession`. Previously, these could also be passed to a `BaseCache` instance.
+* The `CachedSession` `backend` argument must be either an instance or string alias. Previously it would also accept a backend class.
+* After initialization, cache settings can only be accesed and modified via
+  `CachedSession.settings`. Previously, some settings could be modified by setting them on either `CachedSession` or `BaseCache`. In some cases this could silently fail or otherwise have undefined behavior.
+
+The following is relevant for users who have made custom backends that extend built-in storage classes:
+* All `BaseStorage` subclasses now have a `serializer` attribute, which will be unused if
+  set to `None`.
+* All serializer-specific `BaseStorage` subclasses have been removed, and merged into their respective parent classes. This includes `SQLitePickleDict`, `MongoPickleDict`, and `GridFSPickleDict`.
+
+Internal utility module changes:
+* The `cache_control` module (added in `0.7`) has been split up into multiple modules in a new `policy` subpackage
 
 ## 0.9.4 (2022-04-21)
 * Fix forwarding connection parameters passed to `RedisCache` for redis-py 4.2 and python <=3.8

--- a/docs/user_guide/backends/filesystem.md
+++ b/docs/user_guide/backends/filesystem.md
@@ -26,17 +26,9 @@ Or by alias:
 ```
 
 ## File Formats
-By default, responses are saved as pickle files. If you want to save responses in a human-readable
-format, you can use one of the other available {ref}`serializers`. For example, to save responses as
-JSON files:
-```python
->>> session = CachedSession('~/http_cache', backend='filesystem', serializer='json')
->>> session.get('https://httpbin.org/get')
->>> print(list(session.cache.paths()))
-> ['/home/user/http_cache/4dc151d95200ec.json']
-```
-
-Or as YAML (requires `pyyaml`):
+By default, responses are saved as JSON files. If you prefer a deiffernt format, you can use of the
+other available {ref}`serializers` or provide your own. For example, to save responses as
+YAML files (requires `pyyaml`):
 ```python
 >>> session = CachedSession('~/http_cache', backend='filesystem', serializer='yaml')
 >>> session.get('https://httpbin.org/get')

--- a/docs/user_guide/backends/redis.md
+++ b/docs/user_guide/backends/redis.md
@@ -47,6 +47,9 @@ or disabled entirely. See [Redis Persistence](https://redis.io/topics/persistenc
 Redis natively supports TTL on a per-key basis, and can automatically remove expired responses from
 the cache. This will be set by by default, according to normal {ref}`expiration settings <expiration>`.
 
+Expired items are not removed immediately, but will never be returned from the cache. See
+[Redis: EXPIRE](https://redis.io/commands/expire/) docs for more details.
+
 If you intend to reuse expired responses, e.g. with {ref}`conditional-requests` or `stale_if_error`,
 you can disable this behavior with the `ttl` argument:
 ```python

--- a/docs/user_guide/expiration.md
+++ b/docs/user_guide/expiration.md
@@ -142,15 +142,13 @@ You can also apply a new `expire_after` value to previously cached responses:
 >>> session.remove_expired_responses(expire_after=timedelta(days=30))
 ```
 
+(ttl)=
 ### Automatic Removal
 The following backends have native TTL support, which can be used to automatically remove expired
 responses:
+* {py:mod}`DynamoDB <requests_cache.backends.dynamodb>`
 * {py:mod}`MongoDB <requests_cache.backends.mongodb>`
 * {py:mod}`Redis <requests_cache.backends.redis>`
-<!--
-TODO: Not yet supported:
-* {py:mod}`DynamoDB <requests_cache.backends.dynamodb>`
--->
 
 ## Request Options
 In addition to the base arguments for {py:func}`requests.request`, requests-cache adds some extra

--- a/requests_cache/backends/__init__.py
+++ b/requests_cache/backends/__init__.py
@@ -15,35 +15,35 @@ logger = getLogger(__name__)
 
 # Import all backend classes for which dependencies are installed
 try:
-    from .dynamodb import DynamoDbCache, DynamoDbDict, DynamoDbDocumentDict
+    from .dynamodb import DynamoDbCache, DynamoDbDict
 except ImportError as e:
-    DynamoDbCache = DynamoDbDict = DynamoDbDocumentDict = get_placeholder_class(e)  # type: ignore
+    DynamoDbCache = DynamoDbDict = get_placeholder_class(e)  # type: ignore
+
 try:
-    from .gridfs import GridFSCache, GridFSPickleDict
+    from .gridfs import GridFSCache, GridFSDict
 except ImportError as e:
-    GridFSCache = GridFSPickleDict = get_placeholder_class(e)  # type: ignore
+    GridFSCache = GridFSDict = get_placeholder_class(e)  # type: ignore
+
 try:
-    from .mongodb import MongoCache, MongoDict, MongoDocumentDict
+    from .mongodb import MongoCache, MongoDict
 except ImportError as e:
-    MongoCache = MongoDict = MongoDocumentDict = get_placeholder_class(e)  # type: ignore
+    MongoCache = MongoDict = get_placeholder_class(e)  # type: ignore
+
 try:
     from .redis import RedisCache, RedisDict, RedisHashDict
 except ImportError as e:
     RedisCache = RedisDict = RedisHashDict = get_placeholder_class(e)  # type: ignore
+
 try:
-    # Note: Heroku doesn't support SQLite due to ephemeral storage
-    from .sqlite import SQLiteCache, SQLiteDict, SQLitePickleDict
+    from .sqlite import SQLiteCache, SQLiteDict
 except ImportError as e:
-    SQLiteCache = SQLiteDict = SQLitePickleDict = get_placeholder_class(e)  # type: ignore
+    SQLiteCache = SQLiteDict = get_placeholder_class(e)  # type: ignore
+
 try:
     from .filesystem import FileCache, FileDict
 except ImportError as e:
     FileCache = FileDict = get_placeholder_class(e)  # type: ignore
 
-# Aliases for backwards-compatibility
-DbCache = SQLiteCache
-DbDict = SQLiteDict
-DbPickleDict = SQLitePickleDict
 
 BACKEND_CLASSES = {
     'dynamodb': DynamoDbCache,

--- a/requests_cache/backends/base.py
+++ b/requests_cache/backends/base.py
@@ -263,8 +263,8 @@ class BaseStorage(MutableMapping, ABC):
         kwargs: Additional backend-specific keyword arguments
     """
 
-    def __init__(self, serializer=None, **kwargs):
-        self.serializer = init_serializer(serializer)
+    def __init__(self, **kwargs):
+        self.serializer = init_serializer(kwargs.get('serializer', 'pickle'))
         logger.debug(f'Initializing {type(self).__name__} with serializer: {self.serializer}')
 
     def bulk_delete(self, keys: Iterable[str]):
@@ -280,6 +280,14 @@ class BaseStorage(MutableMapping, ABC):
 
     def close(self):
         """Close any open backend connections"""
+
+    def serialize(self, value):
+        """Serialize value, if a serializer is available"""
+        return self.serializer.dumps(value) if self.serializer else value
+
+    def deserialize(self, value):
+        """Deserialize value, if a serializer is available"""
+        return self.serializer.loads(value) if self.serializer else value
 
     def __str__(self):
         return str(list(self.keys()))
@@ -297,7 +305,6 @@ class DictStorage(UserDict, BaseStorage):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._serializer = None
         self.serializer = None
 
     def __getitem__(self, key):

--- a/requests_cache/backends/dynamodb.py
+++ b/requests_cache/backends/dynamodb.py
@@ -34,24 +34,22 @@ class DynamoDbCache(BaseCache):
         table_name: str = 'http_cache',
         ttl: bool = True,
         connection: ServiceResource = None,
-        serializer=None,
         **kwargs,
     ):
         super().__init__(cache_name=table_name, **kwargs)
         self.responses = DynamoDbDict(
             table_name,
-            'responses',
+            namespace='responses',
             ttl=ttl,
-            serializer=serializer or dynamodb_document_serializer,
             connection=connection,
             **kwargs,
         )
         self.redirects = DynamoDbDict(
             table_name,
-            'redirects',
+            namespace='redirects',
             ttl=False,
             connection=self.responses.connection,
-            serializer=None,
+            no_serializer=True,
             **kwargs,
         )
 
@@ -67,6 +65,8 @@ class DynamoDbDict(BaseStorage):
         ttl: Use DynamoDB TTL to automatically remove expired items
         kwargs: Additional keyword arguments for :py:meth:`~boto3.session.Session.resource`
     """
+
+    default_serializer = dynamodb_document_serializer
 
     def __init__(
         self,

--- a/requests_cache/backends/dynamodb.py
+++ b/requests_cache/backends/dynamodb.py
@@ -4,7 +4,6 @@
    :classes-only:
    :nosignatures:
 """
-from time import time
 from typing import Dict, Iterable
 
 import boto3
@@ -151,8 +150,8 @@ class DynamoDbDict(BaseStorage):
         item = {**self._composite_key(key), 'value': self.serialize(value)}
 
         # If enabled, set TTL value as a timestamp in unix format
-        if self.ttl and getattr(value, 'ttl', None):
-            item['ttl'] = round(time() + value.ttl)
+        if self.ttl and getattr(value, 'expires_unix', None):
+            item['ttl'] = value.expires_unix
 
         self._table.put_item(Item=item)
 

--- a/requests_cache/backends/filesystem.py
+++ b/requests_cache/backends/filesystem.py
@@ -91,7 +91,7 @@ class FileDict(BaseStorage):
         mode = 'rb' if self.is_binary else 'r'
         with self._try_io():
             with self._path(key).open(mode) as f:
-                return self.serializer.loads(f.read())
+                return self.deserialize(f.read())
 
     def __delitem__(self, key):
         with self._try_io():
@@ -100,7 +100,7 @@ class FileDict(BaseStorage):
     def __setitem__(self, key, value):
         with self._try_io():
             with self._path(key).open(mode='wb' if self.is_binary else 'w') as f:
-                f.write(self.serializer.dumps(value))
+                f.write(self.serialize(value))
 
     def __iter__(self):
         yield from self.keys()

--- a/requests_cache/backends/filesystem.py
+++ b/requests_cache/backends/filesystem.py
@@ -12,7 +12,7 @@ from shutil import rmtree
 from threading import RLock
 from typing import Iterator
 
-from ..serializers import SERIALIZERS
+from ..serializers import SERIALIZERS, json_serializer
 from . import BaseCache, BaseStorage
 from .sqlite import AnyPath, SQLiteDict, get_cache_path
 
@@ -33,7 +33,7 @@ class FileCache(BaseCache):
         super().__init__(cache_name=str(cache_name), **kwargs)
         self.responses: FileDict = FileDict(cache_name, use_temp=use_temp, **kwargs)
         self.redirects: SQLiteDict = SQLiteDict(
-            self.cache_dir / 'redirects.sqlite', 'redirects', **kwargs
+            self.cache_dir / 'redirects.sqlite', 'redirects', no_serializer=True, **kwargs
         )
 
     @property
@@ -58,6 +58,8 @@ class FileCache(BaseCache):
 
 class FileDict(BaseStorage):
     """A dictionary-like interface to files on the local filesystem"""
+
+    default_serializer = json_serializer
 
     def __init__(
         self,

--- a/requests_cache/backends/gridfs.py
+++ b/requests_cache/backends/gridfs.py
@@ -31,7 +31,11 @@ class GridFSCache(BaseCache):
         super().__init__(cache_name=db_name, **kwargs)
         self.responses = GridFSDict(db_name, **kwargs)
         self.redirects = MongoDict(
-            db_name, collection_name='redirects', connection=self.responses.connection, **kwargs
+            db_name,
+            collection_name='redirects',
+            connection=self.responses.connection,
+            no_serializer=True,
+            **kwargs
         )
 
     def remove_expired_responses(self, *args, **kwargs):

--- a/requests_cache/backends/mongodb.py
+++ b/requests_cache/backends/mongodb.py
@@ -21,6 +21,7 @@ logger = getLogger(__name__)
 
 class MongoCache(BaseCache):
     """MongoDB cache backend.
+    By default, responses are only partially serialized into a MongoDB-compatible document format.
 
     Args:
         db_name: Database name
@@ -28,18 +29,22 @@ class MongoCache(BaseCache):
         kwargs: Additional keyword arguments for :py:class:`pymongo.mongo_client.MongoClient`
     """
 
-    def __init__(self, db_name: str = 'http_cache', connection: MongoClient = None, **kwargs):
+    def __init__(
+        self, db_name: str = 'http_cache', connection: MongoClient = None, serializer=None, **kwargs
+    ):
         super().__init__(cache_name=db_name, **kwargs)
-        self.responses: MongoDict = MongoDocumentDict(
+        self.responses: MongoDict = MongoDict(
             db_name,
             collection_name='responses',
             connection=connection,
+            serializer=serializer or bson_document_serializer,
             **kwargs,
         )
         self.redirects: MongoDict = MongoDict(
             db_name,
             collection_name='redirects',
             connection=self.responses.connection,
+            serializer=None,
             **kwargs,
         )
 
@@ -107,15 +112,17 @@ class MongoDict(BaseStorage):
         result = self.collection.find_one({'_id': key})
         if result is None:
             raise KeyError
-        return result['data'] if 'data' in result else result
+        value = result['data'] if 'data' in result else result
+        return self.deserialize(value)
 
-    def __setitem__(self, key, item):
-        """If ``item`` is already a dict, its values will be stored under top-level keys.
+    def __setitem__(self, key, value):
+        """If ``value`` is already a dict, its values will be stored under top-level keys.
         Otherwise, it will be stored under a 'data' key.
         """
-        if not isinstance(item, Mapping):
-            item = {'data': item}
-        self.collection.replace_one({'_id': key}, item, upsert=True)
+        value = self.serialize(value)
+        if not isinstance(value, Mapping):
+            value = {'data': value}
+        self.collection.replace_one({'_id': key}, value, upsert=True)
 
     def __delitem__(self, key):
         result = self.collection.find_one_and_delete({'_id': key}, {'_id': True})
@@ -138,19 +145,3 @@ class MongoDict(BaseStorage):
 
     def close(self):
         self.connection.close()
-
-
-class MongoDocumentDict(MongoDict):
-    """Same as :class:`MongoDict`, but serializes values before saving.
-
-    By default, responses are only partially serialized into a MongoDB-compatible document format.
-    """
-
-    def __init__(self, *args, serializer=None, **kwargs):
-        super().__init__(*args, serializer=serializer or bson_document_serializer, **kwargs)
-
-    def __getitem__(self, key):
-        return self.serializer.loads(super().__getitem__(key))
-
-    def __setitem__(self, key, item):
-        super().__setitem__(key, self.serializer.dumps(item))

--- a/requests_cache/backends/mongodb.py
+++ b/requests_cache/backends/mongodb.py
@@ -29,22 +29,19 @@ class MongoCache(BaseCache):
         kwargs: Additional keyword arguments for :py:class:`pymongo.mongo_client.MongoClient`
     """
 
-    def __init__(
-        self, db_name: str = 'http_cache', connection: MongoClient = None, serializer=None, **kwargs
-    ):
+    def __init__(self, db_name: str = 'http_cache', connection: MongoClient = None, **kwargs):
         super().__init__(cache_name=db_name, **kwargs)
         self.responses: MongoDict = MongoDict(
             db_name,
             collection_name='responses',
             connection=connection,
-            serializer=serializer or bson_document_serializer,
             **kwargs,
         )
         self.redirects: MongoDict = MongoDict(
             db_name,
             collection_name='redirects',
             connection=self.responses.connection,
-            serializer=None,
+            no_serializer=True,
             **kwargs,
         )
 
@@ -72,6 +69,8 @@ class MongoDict(BaseStorage):
         connection: :py:class:`pymongo.MongoClient` object to reuse instead of creating a new one
         kwargs: Additional keyword arguments for :py:class:`pymongo.MongoClient`
     """
+
+    default_serializer = bson_document_serializer
 
     def __init__(
         self,

--- a/requests_cache/backends/redis.py
+++ b/requests_cache/backends/redis.py
@@ -17,7 +17,7 @@ logger = getLogger(__name__)
 
 
 # TODO: TTL tests
-# TODO: Option to set a different (typically longer) TTL than expire_after, like MongoCache
+# TODO: Option to set a TTL offset, for longer expiration than expire_after
 class RedisCache(BaseCache):
     """Redis cache backend.
 
@@ -79,9 +79,9 @@ class RedisDict(BaseStorage):
 
     def __setitem__(self, key, item):
         """Save an item to the cache, optionally with TTL"""
-        ttl_seconds = getattr(item, 'ttl', None)
-        if self.ttl and ttl_seconds and ttl_seconds > 0:
-            self.connection.setex(self._bkey(key), round(ttl_seconds), self.serialize(item))
+        expires_delta = getattr(item, 'expires_delta', None)
+        if self.ttl and (expires_delta or 0) > 0:
+            self.connection.setex(self._bkey(key), expires_delta, self.serialize(item))
         else:
             self.connection.set(self._bkey(key), self.serialize(item))
 

--- a/requests_cache/backends/sqlite.py
+++ b/requests_cache/backends/sqlite.py
@@ -42,13 +42,11 @@ class SQLiteCache(BaseCache):
         kwargs: Additional keyword arguments for :py:func:`sqlite3.connect`
     """
 
-    def __init__(self, db_path: AnyPath = 'http_cache', serializer=None, **kwargs):
+    def __init__(self, db_path: AnyPath = 'http_cache', **kwargs):
         super().__init__(cache_name=str(db_path), **kwargs)
-        self.responses: SQLiteDict = SQLiteDict(
-            db_path, table_name='responses', serializer=serializer or 'pickle', **kwargs
-        )
+        self.responses: SQLiteDict = SQLiteDict(db_path, table_name='responses', **kwargs)
         self.redirects: SQLiteDict = SQLiteDict(
-            db_path, table_name='redirects', serializer=None, **kwargs
+            db_path, table_name='redirects', no_serializer=True, **kwargs
         )
 
     @property

--- a/requests_cache/models/response.py
+++ b/requests_cache/models/response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 from logging import getLogger
+from time import time
 from typing import TYPE_CHECKING, List, Optional
 
 import attr
@@ -134,12 +135,18 @@ class CachedResponse(BaseResponse, RichMixin):
         return self.expires is not None and datetime.utcnow() >= self.expires
 
     @property
-    def ttl(self) -> Optional[float]:
+    def expires_delta(self) -> Optional[int]:
         """Get time to expiration in seconds (rounded to the nearest second)"""
         if self.expires is None:
             return None
         delta = self.expires - datetime.utcnow()
-        return delta.total_seconds()
+        return round(delta.total_seconds())
+
+    @property
+    def expires_unix(self) -> Optional[int]:
+        """Get expiration time as a Unix timestamp"""
+        seconds = self.expires_delta
+        return round(time() + seconds) if seconds else None
 
     @property
     def next(self) -> Optional[PreparedRequest]:

--- a/requests_cache/models/response.py
+++ b/requests_cache/models/response.py
@@ -134,12 +134,12 @@ class CachedResponse(BaseResponse, RichMixin):
         return self.expires is not None and datetime.utcnow() >= self.expires
 
     @property
-    def ttl(self) -> Optional[int]:
-        """Get time to expiration in seconds"""
-        if self.expires is None or self.is_expired:
+    def ttl(self) -> Optional[float]:
+        """Get time to expiration in seconds (rounded to the nearest second)"""
+        if self.expires is None:
             return None
         delta = self.expires - datetime.utcnow()
-        return int(delta.total_seconds())
+        return delta.total_seconds()
 
     @property
     def next(self) -> Optional[PreparedRequest]:

--- a/requests_cache/serializers/__init__.py
+++ b/requests_cache/serializers/__init__.py
@@ -1,6 +1,8 @@
 """Response serialization utilities. See :ref:`serializers` for general usage info.
 """
 # flake8: noqa: F401
+from typing import Union
+
 from .cattrs import CattrStage
 from .pipeline import SerializerPipeline, Stage
 from .preconf import (
@@ -9,7 +11,6 @@ from .preconf import (
     dict_serializer,
     dynamodb_document_serializer,
     json_serializer,
-    no_op_serializer,
     pickle_serializer,
     safe_pickle_serializer,
     utf8_encoder,
@@ -26,7 +27,6 @@ __all__ = [
     'dynamodb_document_serializer',
     'dict_serializer',
     'json_serializer',
-    'no_op_serializer',
     'pickle_serializer',
     'safe_pickle_serializer',
     'yaml_serializer',
@@ -41,8 +41,10 @@ SERIALIZERS = {
     'yaml': yaml_serializer,
 }
 
+SerializerType = Union[str, SerializerPipeline, Stage]
 
-def init_serializer(serializer):
+
+def init_serializer(serializer: SerializerType = None):
     """Initialize a serializer from a name or instance"""
     if isinstance(serializer, str):
         serializer = SERIALIZERS[serializer]

--- a/requests_cache/serializers/__init__.py
+++ b/requests_cache/serializers/__init__.py
@@ -9,6 +9,7 @@ from .preconf import (
     dict_serializer,
     dynamodb_document_serializer,
     json_serializer,
+    no_op_serializer,
     pickle_serializer,
     safe_pickle_serializer,
     utf8_encoder,
@@ -25,6 +26,7 @@ __all__ = [
     'dynamodb_document_serializer',
     'dict_serializer',
     'json_serializer',
+    'no_op_serializer',
     'pickle_serializer',
     'safe_pickle_serializer',
     'yaml_serializer',
@@ -40,9 +42,8 @@ SERIALIZERS = {
 }
 
 
-def init_serializer(serializer=None):
+def init_serializer(serializer):
     """Initialize a serializer from a name or instance"""
-    serializer = serializer or 'pickle'
     if isinstance(serializer, str):
         serializer = SERIALIZERS[serializer]
     return serializer

--- a/requests_cache/serializers/pipeline.py
+++ b/requests_cache/serializers/pipeline.py
@@ -9,7 +9,8 @@ from ..models import CachedResponse
 
 
 class Stage:
-    """Generic class to wrap serialization steps with consistent ``dumps()`` and ``loads()`` methods
+    """A single stage in a serializer pipeline. This wraps serialization steps with consistent
+    ``dumps()`` and ``loads()`` methods
 
     Args:
         obj: Serializer object or module, if applicable

--- a/requests_cache/serializers/preconf.py
+++ b/requests_cache/serializers/preconf.py
@@ -55,7 +55,7 @@ dict_serializer = SerializerPipeline(
 pickle_serializer = SerializerPipeline(
     [base_stage, pickle], name='pickle', is_binary=True
 )  #: Pickle serializer
-
+no_op_serializer = SerializerPipeline([], name='no_op')  #: Placeholder serializer that does nothing
 
 # Safe pickle serializer
 def signer_stage(secret_key=None, salt='requests-cache') -> Stage:

--- a/requests_cache/serializers/preconf.py
+++ b/requests_cache/serializers/preconf.py
@@ -53,9 +53,8 @@ dict_serializer = SerializerPipeline(
     [base_stage], name='dict', is_binary=False
 )  #: Partial serializer that unstructures responses into dicts
 pickle_serializer = SerializerPipeline(
-    [base_stage, pickle], name='pickle', is_binary=True
+    [base_stage, Stage(pickle)], name='pickle', is_binary=True
 )  #: Pickle serializer
-no_op_serializer = SerializerPipeline([], name='no_op')  #: Placeholder serializer that does nothing
 
 # Safe pickle serializer
 def signer_stage(secret_key=None, salt='requests-cache') -> Stage:
@@ -77,7 +76,7 @@ def safe_pickle_serializer(secret_key=None, salt='requests-cache', **kwargs) -> 
     responses on write, and validate that signature with a secret key on read.
     """
     return SerializerPipeline(
-        [base_stage, pickle, signer_stage(secret_key, salt)],
+        [base_stage, Stage(pickle), signer_stage(secret_key, salt)],
         name='safe_pickle',
         is_binary=True,
     )

--- a/requests_cache/session.py
+++ b/requests_cache/session.py
@@ -25,7 +25,7 @@ from .policy import (
     KeyCallback,
     set_request_headers,
 )
-from .serializers import SerializerPipeline
+from .serializers import SerializerType
 
 __all__ = ['CachedSession', 'CacheMixin']
 if TYPE_CHECKING:
@@ -45,7 +45,7 @@ class CacheMixin(MIXIN_BASE):
         self,
         cache_name: str = DEFAULT_CACHE_NAME,
         backend: BackendSpecifier = None,
-        serializer: Union[str, SerializerPipeline] = None,
+        serializer: SerializerType = None,
         expire_after: ExpirationTime = -1,
         urls_expire_after: ExpirationPatterns = None,
         cache_control: bool = False,

--- a/tests/integration/base_cache_test.py
+++ b/tests/integration/base_cache_test.py
@@ -44,7 +44,6 @@ logger = getLogger(__name__)
 # Handle optional dependencies if they're not installed,
 # so any skipped tests will explicitly be shown in pytest output
 TEST_SERIALIZERS = SERIALIZERS.copy()
-TEST_SERIALIZERS['no_op'] = None
 try:
     TEST_SERIALIZERS['safe_pickle'] = safe_pickle_serializer(secret_key='hunter2')
 except ImportError:
@@ -53,7 +52,7 @@ VALIDATOR_HEADERS = [{'ETag': ETAG}, {'Last-Modified': LAST_MODIFIED}]
 
 
 def _valid_serializer(serializer) -> bool:
-    return isinstance(serializer, (SerializerPipeline, Stage)) or serializer is None
+    return isinstance(serializer, (SerializerPipeline, Stage))
 
 
 class BaseCacheTest:
@@ -317,6 +316,8 @@ class BaseCacheTest:
         session.get(httpbin('get'), expire_after=-1)
         session.get(httpbin('redirect/3'), expire_after=-1)
         assert len(session.cache.redirects.keys()) == 4
+        print(list(session.cache.redirects.items()))
+        print(list(session.cache.responses.keys()))
         session.cache.remove_expired_responses()
 
         assert len(session.cache.responses.keys()) == 2

--- a/tests/integration/base_storage_test.py
+++ b/tests/integration/base_storage_test.py
@@ -14,7 +14,6 @@ class BaseStorageTest:
 
     storage_class: Type[BaseStorage] = None
     init_kwargs: Dict = {}
-    picklable: bool = False
     num_instances: int = 10  # Max number of cache instances to test
 
     def init_cache(self, cache_name=CACHE_NAME, index=0, clear=True, **kwargs):
@@ -98,21 +97,20 @@ class BaseStorageTest:
             cache['key']
 
     def test_picklable_dict(self):
-        if self.picklable:
-            cache = self.init_cache(serializer='pickle')
-            original_obj = BasicDataclass(
-                bool_attr=True,
-                datetime_attr=datetime(2022, 2, 2),
-                int_attr=2,
-                str_attr='value',
-            )
-            cache['key_1'] = original_obj
+        cache = self.init_cache(serializer='pickle')
+        original_obj = BasicDataclass(
+            bool_attr=True,
+            datetime_attr=datetime(2022, 2, 2),
+            int_attr=2,
+            str_attr='value',
+        )
+        cache['key_1'] = original_obj
 
-            obj = cache['key_1']
-            assert obj.bool_attr == original_obj.bool_attr
-            assert obj.datetime_attr == original_obj.datetime_attr
-            assert obj.int_attr == original_obj.int_attr
-            assert obj.str_attr == original_obj.str_attr
+        obj = cache['key_1']
+        assert obj.bool_attr == original_obj.bool_attr
+        assert obj.datetime_attr == original_obj.datetime_attr
+        assert obj.int_attr == original_obj.int_attr
+        assert obj.str_attr == original_obj.str_attr
 
     def test_clear_and_work_again(self):
         cache_1 = self.init_cache()

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -69,7 +69,7 @@ class TestDynamoDbDict(BaseStorageTest):
         """
         cache = self.init_cache(ttl=ttl_enabled)
         item = OrderedDict(foo='bar')
-        item.ttl = 60
+        item.expires_unix = 60
         cache['key'] = item
 
         # 'ttl' is a reserved word, so to retrieve it we need to alias it

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 from botocore.exceptions import ClientError
 
-from requests_cache.backends import DynamoDbCache, DynamoDbDict, DynamoDbDocumentDict
+from requests_cache.backends import DynamoDbCache, DynamoDbDict
 from requests_cache.serializers import dynamodb_document_serializer
 from tests.conftest import HTTPBIN_FORMATS, HTTPBIN_METHODS, fail_if_no_connection
 from tests.integration.base_cache_test import TEST_SERIALIZERS, BaseCacheTest
@@ -84,12 +84,6 @@ class TestDynamoDbDict(BaseStorageTest):
             assert isinstance(ttl_value, Decimal)
         else:
             assert ttl_value is None
-
-
-class TestDynamoDbDocumentDict(BaseStorageTest):
-    storage_class = DynamoDbDocumentDict
-    init_kwargs = DYNAMODB_OPTIONS
-    picklable = True
 
 
 class TestDynamoDbCache(BaseCacheTest):

--- a/tests/integration/test_mongodb.py
+++ b/tests/integration/test_mongodb.py
@@ -6,14 +6,8 @@ import pytest
 from gridfs import GridFS
 from gridfs.errors import CorruptGridFile, FileExists
 
-from requests_cache.backends import (
-    GridFSCache,
-    GridFSPickleDict,
-    MongoCache,
-    MongoDict,
-    MongoDocumentDict,
-)
-from requests_cache.policy.expiration import NEVER_EXPIRE
+from requests_cache.backends import GridFSCache, GridFSDict, MongoCache, MongoDict
+from requests_cache.policy import NEVER_EXPIRE
 from requests_cache.serializers import bson_document_serializer
 from tests.conftest import HTTPBIN_FORMATS, HTTPBIN_METHODS, fail_if_no_connection, httpbin
 from tests.integration.base_cache_test import TEST_SERIALIZERS, BaseCacheTest
@@ -37,11 +31,6 @@ def ensure_connection():
 class TestMongoDict(BaseStorageTest):
     storage_class = MongoDict
 
-
-class TestMongoPickleDict(BaseStorageTest):
-    storage_class = MongoDocumentDict
-    picklable = True
-
     def test_connection_kwargs(self):
         """A spot check to make sure optional connection kwargs gets passed to connection"""
         # MongoClient prevents direct access to private members like __init_kwargs;
@@ -60,7 +49,6 @@ class TestMongoPickleDict(BaseStorageTest):
 
 class TestMongoCache(BaseCacheTest):
     backend_class = MongoCache
-
     init_kwargs = {'serializer': None}  # Use class default serializer instead of pickle
 
     @pytest.mark.parametrize('serializer', MONGODB_SERIALIZERS)
@@ -113,14 +101,14 @@ class TestMongoCache(BaseCacheTest):
         assert session.cache.get_ttl() is None
 
 
-class TestGridFSPickleDict(BaseStorageTest):
-    storage_class = GridFSPickleDict
+class TestGridFSDict(BaseStorageTest):
+    storage_class = GridFSDict
     picklable = True
     num_instances = 1  # Only test a single collecton instead of multiple
 
     def test_connection_kwargs(self):
         """A spot check to make sure optional connection kwargs gets passed to connection"""
-        cache = GridFSPickleDict(
+        cache = GridFSDict(
             'test',
             host='mongodb://0.0.0.0',
             port=2222,

--- a/tests/integration/test_sqlite.py
+++ b/tests/integration/test_sqlite.py
@@ -219,12 +219,19 @@ class TestSQLiteDict(BaseStorageTest):
             assert prev_item is None or prev_item.expires < item.expires
             assert item.status_code % 2 == 0
 
-    def test_filesize(self):
-        """Test approximate expected size of database file, in bytes"""
-        cache = self.init_cache()
+    @pytest.mark.parametrize(
+        'db_path, use_temp',
+        [
+            ('filesize_test', True),
+            (':memory:', False),
+        ],
+    )
+    def test_size(self, db_path, use_temp):
+        """Test approximate expected size of a database, for both file-based and in-memory databases"""
+        cache = self.init_cache(db_path, use_temp=use_temp)
         for i in range(100):
             cache[f'key_{i}'] = f'value_{i}'
-        assert 50000 < cache.filesize() < 200000
+        assert 10000 < cache.size() < 200000
 
 
 class TestSQLiteCache(BaseCacheTest):

--- a/tests/integration/test_sqlite.py
+++ b/tests/integration/test_sqlite.py
@@ -9,13 +9,14 @@ import pytest
 from platformdirs import user_cache_dir
 
 from requests_cache.backends.base import BaseCache
-from requests_cache.backends.sqlite import MEMORY_URI, SQLiteCache, SQLiteDict, SQLitePickleDict
+from requests_cache.backends.sqlite import MEMORY_URI, SQLiteCache, SQLiteDict
 from requests_cache.models.response import CachedResponse
 from tests.integration.base_cache_test import BaseCacheTest
 from tests.integration.base_storage_test import CACHE_NAME, BaseStorageTest
 
 
-class SQLiteTestCase(BaseStorageTest):
+class TestSQLiteDict(BaseStorageTest):
+    storage_class = SQLiteDict
     init_kwargs = {'use_temp': True}
 
     @classmethod
@@ -178,15 +179,6 @@ class SQLiteTestCase(BaseStorageTest):
         with pytest.raises(ValueError):
             list(cache.sorted(key='invalid_key'))
 
-
-class TestSQLiteDict(SQLiteTestCase):
-    storage_class = SQLiteDict
-
-
-class TestSQLitePickleDict(SQLiteTestCase):
-    storage_class = SQLitePickleDict
-    picklable = True
-
     @pytest.mark.parametrize('limit', [None, 50])
     def test_sorted__by_expires(self, limit):
         cache = self.init_cache()
@@ -213,7 +205,7 @@ class TestSQLitePickleDict(SQLiteTestCase):
         for i in range(100):
             delta = 101 - i
             if i % 2 == 1:
-                delta -= 100
+                delta -= 101
 
             response = CachedResponse(status_code=i, expires=now + timedelta(seconds=delta))
             cache[f'key_{i}'] = response
@@ -226,6 +218,13 @@ class TestSQLitePickleDict(SQLiteTestCase):
         for i, item in enumerate(items):
             assert prev_item is None or prev_item.expires < item.expires
             assert item.status_code % 2 == 0
+
+    def test_filesize(self):
+        """Test approximate expected size of database file, in bytes"""
+        cache = self.init_cache()
+        for i in range(100):
+            cache[f'key_{i}'] = f'value_{i}'
+        assert 50000 < cache.filesize() < 200000
 
 
 class TestSQLiteCache(BaseCacheTest):

--- a/tests/unit/test_base_cache.py
+++ b/tests/unit/test_base_cache.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from requests_cache import CachedResponse
-from requests_cache.backends import BaseCache, SQLitePickleDict
+from requests_cache.backends import BaseCache, SQLiteDict
 from tests.conftest import MOCKED_URL, MOCKED_URL_HTTPS, MOCKED_URL_JSON, MOCKED_URL_REDIRECT
 
 YESTERDAY = datetime.utcnow() - timedelta(days=1)
@@ -24,7 +24,7 @@ class TimeBomb:
 def test_urls__with_invalid_response(mock_session):
     responses = [mock_session.get(url) for url in [MOCKED_URL, MOCKED_URL_JSON, MOCKED_URL_HTTPS]]
     responses[2] = AttributeError
-    with patch.object(SQLitePickleDict, '__getitem__', side_effect=responses):
+    with patch.object(SQLiteDict, '__getitem__', side_effect=responses):
         expected_urls = [MOCKED_URL, MOCKED_URL_JSON]
         assert set(mock_session.cache.urls) == set(expected_urls)
 
@@ -67,7 +67,7 @@ def test_values__with_invalid_responses(check_expiry, expected_count, mock_sessi
     responses[1] = AttributeError
     responses[2] = CachedResponse(expires=YESTERDAY, url='test')
 
-    with patch.object(SQLitePickleDict, '__getitem__', side_effect=responses):
+    with patch.object(SQLiteDict, '__getitem__', side_effect=responses):
         values = mock_session.cache.values(check_expiry=check_expiry)
         assert len(list(values)) == expected_count
 

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -691,17 +691,17 @@ def test_remove_expired_responses__per_request(mock_session):
     mock_session.mock_adapter.register_uri('GET', second_url, status_code=200)
     mock_session.mock_adapter.register_uri('GET', third_url, status_code=200)
     mock_session.get(MOCKED_URL)
-    mock_session.get(second_url, expire_after=1)
-    mock_session.get(third_url, expire_after=2)
+    mock_session.get(second_url, expire_after=2)
+    mock_session.get(third_url, expire_after=4)
 
     # All 3 responses should still be cached
     mock_session.remove_expired_responses()
     for response in mock_session.cache.responses.values():
-        logger.info(f'Expires in {response.ttl} seconds')
+        logger.info(f'Expires in {response.expires_delta} seconds')
     assert len(mock_session.cache.responses) == 3
 
-    # One should be expired after 1s, and another should be expired after 2s
-    time.sleep(1)
+    # One should be expired after 2s, and another should be expired after 4s
+    time.sleep(2)
     mock_session.remove_expired_responses()
     assert len(mock_session.cache.responses) == 2
     time.sleep(2)


### PR DESCRIPTION
Closes #609 

This also fixes an issue with expiration in the SQLite backend: the current time was being set using `datetime.utcnow().timestamp()`, which is apparently not a reliable way to get Unix time. Now just using `time.time()`