### PR TITLE
 Add a secondary cache key for Vary

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 * Add tests for python 3.15 (alpha)
+* Add support for multiple response variations based on `Vary`
 
 ## 1.3.0 (2026-02-02)
 

--- a/docs/user_guide/matching.md
+++ b/docs/user_guide/matching.md
@@ -66,8 +66,10 @@ In some cases, request header values can affect response content. For example, s
 i18n and [content negotiation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Content_negotiation) may use the `Accept-Language` header to determine which language to serve content in.
 
 The server will ideally also send a `Vary` header in the response, which informs caches about
-which request headers to match. By default, requests-cache respects this, so in many cases it
-will already do what you want without extra configuration. Not all servers send `Vary`, however.
+which request headers to match. By default, requests-cache respects this: each unique combination
+of Vary-specified header values is cached separately, so alternating between variants (e.g.,
+different `Accept` values for content negotiation) works correctly without extra configuration.
+Not all servers send `Vary`, however.
 ```
 
 Use the `match_headers` option if you want to specify which headers you want to match when `Vary`

--- a/requests_cache/policy/actions.py
+++ b/requests_cache/policy/actions.py
@@ -67,6 +67,7 @@ class CacheActions(RichMixin):
     resend_async: bool = field(default=False)
     skip_read: bool = field(default=False)
     skip_write: bool = field(default=False)
+    vary_cache_key: Optional[str] = field(default=None)
 
     # Inputs
     _directives: CacheDirectives = field(default=None, repr=False)
@@ -347,14 +348,19 @@ class CacheActions(RichMixin):
             return True
 
         key_kwargs['match_headers'] = match_headers
-        vary_cache_key = create_key(vary_request, **key_kwargs)
-        headers_match = create_key(self._request, **key_kwargs) == vary_cache_key
+        vary_key_cached = create_key(vary_request, **key_kwargs)
+        vary_key_current = create_key(self._request, **key_kwargs)
+        headers_match = vary_key_current == vary_key_cached
         if not headers_match:
             _log_vary_diff(
                 self._request.headers,
-                cached_response.request.headers,
+                vary_request.headers,
                 key_kwargs['match_headers'],
             )
+            # Compute secondary cache key with merged Vary + user match_headers
+            merged = self._merge_match_headers(match_headers)
+            key_kwargs['match_headers'] = merged
+            self.vary_cache_key = create_key(self._request, **key_kwargs)
         return headers_match
 
     def _cookies_match(self, cached_request: 'CachedRequest') -> bool:
@@ -367,6 +373,16 @@ class CacheActions(RichMixin):
         cached_cookies = normalize_cookies(cached_request.cookies)
         request_cookies = normalize_cookies(getattr(self._request, '_cookies', None))
         return request_cookies == cached_cookies
+
+    def _merge_match_headers(self, vary_headers: List[str]) -> Union[List[str], bool]:
+        """Merge Vary headers with user-configured match_headers to build a complete
+        set of headers for the secondary cache key."""
+        user_headers = self._settings.match_headers
+        if user_headers is True:
+            return True
+        if not user_headers:
+            return vary_headers
+        return sorted(set(vary_headers + [h.lower() for h in user_headers]))
 
 
 def _is_method_allowed(request: PreparedRequest, settings: CacheSettings) -> bool:

--- a/tests/unit/policy/test_actions.py
+++ b/tests/unit/policy/test_actions.py
@@ -327,6 +327,92 @@ def test_update_from_cached_response__vary_headers(
 
 
 @pytest.mark.parametrize(
+    'vary, cached_headers, new_headers, expect_vary_key_set',
+    [
+        # Vary mismatch: secondary key should be set (and differ from base key)
+        ({'Vary': 'Accept'}, {'Accept': 'application/json'}, {'Accept': 'text/html'}, True),
+        # Vary match: no secondary key needed
+        ({'Vary': 'Accept'}, {'Accept': 'application/json'}, {'Accept': 'application/json'}, False),
+        # Vary: * always misses, but no secondary lookup is possible
+        ({'Vary': '*'}, {'Accept': 'application/json'}, {'Accept': 'application/json'}, False),
+        # No Vary header: no secondary key
+        ({}, {}, {}, False),
+        # Vary: Cookie with matching cookies: no secondary key (cookies match, so cache hit)
+        ({'Vary': 'Cookie'}, {}, {}, False),
+    ],
+)
+def test_vary_cache_key(vary, cached_headers, new_headers, expect_vary_key_set):
+    cached_response = CachedResponse(
+        headers=vary,
+        request=Request(method='GET', url='https://site.com/img.jpg', headers=cached_headers),
+    )
+    request = Request(method='GET', url='https://site.com/img.jpg', headers=new_headers)
+    actions = CacheActions.from_request('key', request)
+    actions.update_from_cached_response(cached_response, create_key=create_key)
+
+    if expect_vary_key_set:
+        assert actions.vary_cache_key is not None
+        assert actions.vary_cache_key != actions.cache_key
+    else:
+        assert actions.vary_cache_key is None
+
+
+def test_vary_cache_key__merges_user_match_headers():
+    """vary_cache_key should incorporate user match_headers along with Vary headers"""
+    cached_response = CachedResponse(
+        headers={'Vary': 'Accept'},
+        request=Request(
+            method='GET',
+            url='https://site.com/img.jpg',
+            headers={'Accept': 'application/json', 'Authorization': 'Bearer token1'},
+        ),
+    )
+    request = Request(
+        method='GET',
+        url='https://site.com/img.jpg',
+        headers={'Accept': 'text/html', 'Authorization': 'Bearer token2'},
+    )
+    settings = CacheSettings(match_headers=['Authorization'])
+    actions = CacheActions.from_request('key', request, settings=settings)
+    actions.update_from_cached_response(cached_response, create_key=create_key)
+
+    assert actions.vary_cache_key is not None
+
+    # The secondary key should differ from a key built with only Vary headers
+    request_2 = Request(
+        method='GET',
+        url='https://site.com/img.jpg',
+        headers={'Accept': 'text/html', 'Authorization': 'Bearer token_different'},
+    )
+    actions_2 = CacheActions.from_request('key', request_2, settings=settings)
+    actions_2.update_from_cached_response(cached_response, create_key=create_key)
+    assert actions_2.vary_cache_key != actions.vary_cache_key
+
+
+def test_vary_cache_key__match_all():
+    """vary_cache_key should be set when match_headers=True (match all headers)"""
+    cached_response = CachedResponse(
+        headers={'Vary': 'Accept'},
+        request=Request(
+            method='GET',
+            url='https://site.com/img.jpg',
+            headers={'Accept': 'application/json'},
+        ),
+    )
+    request = Request(
+        method='GET',
+        url='https://site.com/img.jpg',
+        headers={'Accept': 'text/html'},
+    )
+    settings = CacheSettings(match_headers=True)
+    actions = CacheActions.from_request('key', request, settings=settings)
+    actions.update_from_cached_response(cached_response, create_key=create_key)
+
+    assert actions.vary_cache_key is not None
+    assert actions.vary_cache_key != actions.cache_key
+
+
+@pytest.mark.parametrize(
     'cached_cookies, new_cookies, expected_match',
     [
         ({'session': 'abc123'}, {'session': 'abc123'}, True),
@@ -399,6 +485,8 @@ def test_update_from_cached_response__vary_cookie_and_headers():
 
     # Should be a cache miss because Accept header differs
     assert actions.send_request is True
+    # Cookies match, so secondary key is set for the differing Accept header
+    assert actions.vary_cache_key is not None
 
 
 @pytest.mark.parametrize('max_stale, usable', [(5, False), (15, True)])

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -378,7 +378,32 @@ def test_match_headers__vary(mock_session):
 
     assert mock_session.get(MOCKED_URL_VARY, headers=headers_1).from_cache is True
     assert mock_session.get(MOCKED_URL_VARY, headers=headers_2).from_cache is True
+    # First request with mismatched Vary header is a cache miss
     assert mock_session.get(MOCKED_URL_VARY, headers=headers_3).from_cache is False
+    # Second request with same mismatched headers should now be a cache hit
+    # (stored under Vary-qualified key on the previous miss)
+    assert mock_session.get(MOCKED_URL_VARY, headers=headers_3).from_cache is True
+
+
+def test_match_headers__vary_alternating(mock_session):
+    """Alternating between two Accept values should not cause endless cache misses.
+    After the first round of requests, each variant should be cached under its own
+    Vary-qualified key and served from cache on subsequent requests.
+    """
+    headers_json = {'Accept': 'application/json'}
+    headers_html = {'Accept': 'text/html'}
+
+    # First round: both are cache misses (populating the cache)
+    assert mock_session.get(MOCKED_URL_VARY, headers=headers_json).from_cache is False
+    assert mock_session.get(MOCKED_URL_VARY, headers=headers_html).from_cache is False
+
+    # Second round: both should be cache hits
+    assert mock_session.get(MOCKED_URL_VARY, headers=headers_json).from_cache is True
+    assert mock_session.get(MOCKED_URL_VARY, headers=headers_html).from_cache is True
+
+    # Third round: still cache hits
+    assert mock_session.get(MOCKED_URL_VARY, headers=headers_json).from_cache is True
+    assert mock_session.get(MOCKED_URL_VARY, headers=headers_html).from_cache is True
 
 
 @pytest.mark.parametrize(
@@ -404,6 +429,22 @@ def test_match_headers__vary_with_redirects(headers, expected_from_cache, mock_s
 
     r2 = mock_session.get(MOCKED_URL_VARY_REDIRECT, headers=headers)
     assert r2.from_cache is expected_from_cache
+
+
+def test_match_headers__vary_alternating_with_redirects(mock_session):
+    """Secondary Vary lookup should work correctly through redirect chains.
+    Each Accept-Language variant should be cached under its own Vary-qualified key.
+    """
+    headers_en = {'Accept': 'text/plain', 'Accept-Language': 'en-US'}
+    headers_gb = {'Accept': 'text/plain', 'Accept-Language': 'en-GB'}
+
+    # First round: both are cache misses
+    assert mock_session.get(MOCKED_URL_VARY_REDIRECT, headers=headers_en).from_cache is False
+    assert mock_session.get(MOCKED_URL_VARY_REDIRECT, headers=headers_gb).from_cache is False
+
+    # Second round: both should be cache hits
+    assert mock_session.get(MOCKED_URL_VARY_REDIRECT, headers=headers_en).from_cache is True
+    assert mock_session.get(MOCKED_URL_VARY_REDIRECT, headers=headers_gb).from_cache is True
 
 
 def test_include_get_headers():


### PR DESCRIPTION
Closes #1137 

 When the primary cache lookup finds a response but Vary headers don't match:
  1. Create a secondary key based on the current request's Vary headers
  2. If found, use that response (if other usual checks pass)
  3. If not found, fetch a new response and store the result under the secondary key

This is a compromise to minimize additional backend calls by only checking for the secondary cache key when Vary validation fails.