### PR TITLE
Set a timeout on basic patching HTTP calls

### DIFF
--- a/examples/basic_patching.py
+++ b/examples/basic_patching.py
@@ -12,19 +12,21 @@ import requests_cache
 # After installation, all requests functions and Session methods will be cached
 requests_cache.install_cache('example_cache', backend='sqlite')
 
+TIMEOUT = 10.0
+
 
 def main():
     # The real request will only be made once; afterward, the cached response is used
     for _ in range(5):
-        response = requests.get('https://httpbin.org/get')
+        response = requests.get('https://httpbin.org/get', timeout=TIMEOUT)
 
     # This is more obvious when calling a slow endpoint
     for _ in range(5):
-        response = requests.get('https://httpbin.org/delay/2')
+        response = requests.get('https://httpbin.org/delay/2', timeout=TIMEOUT)
 
     # Caching can be disabled if we want to get a fresh page and not cache it
     with requests_cache.disabled():
-        print(requests.get('https://httpbin.org/ip').text)
+        print(requests.get('https://httpbin.org/ip', timeout=TIMEOUT).text)
 
     # Get some debugging info about the cache
     print(requests_cache.get_cache())

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -18,7 +18,7 @@ from rich.progress import Progress
 
 from requests_cache import CachedResponse, CachedSession
 
-BASE_RESPONSE = requests.get('https://httpbin.org/get')
+BASE_RESPONSE = requests.get('https://httpbin.org/get', timeout=10.0)
 CACHE_NAME = 'benchmark_cache'
 WARMUP_ITERATIONS = 100
 ITERATIONS = 5000

--- a/examples/generate_test_db.py
+++ b/examples/generate_test_db.py
@@ -23,7 +23,7 @@ MAX_RESPONSE_SIZE = 10000  # In bytes
 N_RESPONSES = 100000
 N_INVALID_RESPONSES = 10
 
-BASE_RESPONSE = requests.get('https://httpbin.org/get')
+BASE_RESPONSE = requests.get('https://httpbin.org/get', timeout=10.0)
 HTTPBIN_EXTRA_ENDPOINTS = [
     'anything',
     'bytes/1024' 'cookies',

--- a/examples/log_requests.py
+++ b/examples/log_requests.py
@@ -20,7 +20,7 @@ logger = getLogger('requests_cache.examples')
 @contextmanager
 def log_requests():
     """Context manager that mocks and logs all non-cached requests"""
-    real_response = set_response_defaults(requests.get('https://httpbin.org/get'))
+    real_response = set_response_defaults(requests.get('https://httpbin.org/get', timeout=10.0))
     with patch.object(OriginalSession, 'send', return_value=real_response) as mock_send:
         session = CachedSession('cache-test', backend='sqlite')
         session.cache.clear()

--- a/examples/pygithub.py
+++ b/examples/pygithub.py
@@ -78,8 +78,8 @@ def get_user_info():
 
 def test_non_github_requests():
     """Test that URL patterns are working, and that non-GitHub requests are not cached"""
-    response = requests.get('https://httpbin.org/json')
-    response = requests.get('https://httpbin.org/json')
+    response = requests.get('https://httpbin.org/json', timeout=10.0)
+    response = requests.get('https://httpbin.org/json', timeout=10.0)
     from_cache = getattr(response, 'from_cache', False)
     print(f'Non-GitHub requests cached: {from_cache}')
     assert not from_cache
@@ -92,7 +92,7 @@ def check_cache():
     print('\n'.join(get_cache().urls()))
 
     # Make sure credentials were redacted from all responses in the cache
-    response = requests.get('https://api.github.com/user/repos')
+    response = requests.get('https://api.github.com/user/repos', timeout=10.0)
     print('\nExample cached request headers:')
     print(response.request.headers)
     for response in get_cache().responses.values():

--- a/examples/time_machine_backtesting.py
+++ b/examples/time_machine_backtesting.py
@@ -17,7 +17,7 @@ class BacktestCachedSession(CachedSession):
 
         # Response was cached after the (simulated) current time, so ignore it and send a new request
         if response.created_at and response.created_at > datetime.now(UTC):
-            new_response = requests.request(method, url, **kwargs)
+            new_response = requests.request(method, url, **kwargs, timeout=10.0)
             return set_response_defaults(new_response)
         else:
             return response

--- a/tests/compat/test_requests_mock_disable_cache.py
+++ b/tests/compat/test_requests_mock_disable_cache.py
@@ -18,9 +18,9 @@ def test_requests_cache_mock(requests_cache_mock):
     requests_cache_mock.get(url, text='Mock response!')
 
     # Make sure the mocker is used
-    response_1 = requests.get(url)
+    response_1 = requests.get(url, timeout=10.0)
     assert response_1.text == 'Mock response!'
 
     # Make sure the cache is not used
-    response_2 = requests.get(url)
+    response_2 = requests.get(url, timeout=10.0)
     assert getattr(response_2, 'from_cache', False) is False

--- a/tests/compat/test_requests_mock_load_cache.py
+++ b/tests/compat/test_requests_mock_load_cache.py
@@ -46,7 +46,7 @@ def test_mock_session(mock_http_adapter, mock_session):
     """Test that the mock_session fixture is working as expected"""
     # An error will be raised if a real request is made
     with pytest.raises(ValueError):
-        requests.get(TEST_URLS[0])
+        requests.get(TEST_URLS[0], timeout=10.0)
 
     # All mocked URLs will return a response based on requests-cache data
     for url in TEST_URLS:
@@ -64,7 +64,7 @@ def save_test_data():
     """
     session = CachedSession(TEST_DB)
     for url in TEST_URLS:
-        session.get(url)
+        session.get(url, timeout=10.0)
 
 
 if __name__ == '__main__':

--- a/tests/compat/test_responses_load_cache.py
+++ b/tests/compat/test_responses_load_cache.py
@@ -53,13 +53,13 @@ def test_mock_session(mock_http_adapter):
     with get_responses():
         # An error will be raised if a real request is made
         with pytest.raises(ValueError):
-            requests.get(PASSTHRU_URL)
+            requests.get(PASSTHRU_URL, timeout=10.0)
 
         # All mocked URLs will return a response based on requests-cache data
         for url in TEST_URLS:
-            response = requests.get(url)
+            response = requests.get(url, timeout=10.0)
             assert getattr(response, 'from_cache', False) is False
 
         # responses will raise an error for an unmocked URL, as usual
         with pytest.raises(ConnectionError):
-            requests.get(UNMOCKED_URL)
+            requests.get(UNMOCKED_URL, timeout=10.0)

--- a/tests/integration/base_cache_test.py
+++ b/tests/integration/base_cache_test.py
@@ -199,7 +199,7 @@ class BaseCacheTest:
         be added. The `/cache` endpoint returns a 304 if one of these request headers is present.
         When this happens, the previously cached response should be returned.
         """
-        response = requests.get(httpbin('cache'))
+        response = requests.get(httpbin('cache'), timeout=10.0)
         response.headers = cached_response_headers
 
         session = self.init_session(cache_control=True)

--- a/tests/unit/test_patcher.py
+++ b/tests/unit/test_patcher.py
@@ -77,7 +77,7 @@ def test_clear__not_installed(mock_clear):
 def test_disabled(cached_request, original_request, installed_session):
     with requests_cache.disabled():
         for _ in range(3):
-            requests.get('some_url')
+            requests.get('some_url', timeout=10.0)
     assert cached_request.call_count == 0
     assert original_request.call_count == 3
 
@@ -87,7 +87,7 @@ def test_disabled(cached_request, original_request, installed_session):
 def test_enabled(cached_request, original_request, tempfile_path):
     with requests_cache.enabled(tempfile_path):
         for _ in range(3):
-            requests.get('some_url')
+            requests.get('some_url', timeout=10.0)
     assert cached_request.call_count == 3
     assert original_request.call_count == 0
 


### PR DESCRIPTION
I noticed this while tracing through examples/basic_patching.py. Set a timeout on basic patching HTTP calls. Network calls without a timeout can hang a worker indefinitely. I kept the patch small and re-ran syntax checks after applying it.