### PR TITLE
Fix IndexError when Expires header value is an empty string

### DIFF
--- a/requests_cache/policy/expiration.py
+++ b/requests_cache/policy/expiration.py
@@ -30,6 +30,7 @@ def get_expiration_datetime(
     # Expires headers arrive as integer strings (eg. '0'...or even '-1' if you are Azure...)
     if (
         isinstance(expire_after, str)
+        and expire_after
         and (expire_after[1:] if expire_after[0] == '-' else expire_after).isdigit()
     ):
         expire_after = EXPIRE_IMMEDIATELY

--- a/tests/unit/policy/test_expiration.py
+++ b/tests/unit/policy/test_expiration.py
@@ -54,6 +54,13 @@ def test_get_expiration_datetime__httpdate():
         get_expiration_datetime('P12Y34M56DT78H90M12.345S')
 
 
+def test_get_expiration_datetime__empty_string():
+    """An empty Expires header should raise ValueError, not IndexError"""
+    assert get_expiration_datetime('', ignore_invalid_httpdate=True) is None
+    with pytest.raises(ValueError):
+        get_expiration_datetime('')
+
+
 @pytest.mark.parametrize(
     'url, expected_expire_after',
     [


### PR DESCRIPTION
## Summary

An empty `Expires:` response header (sent by some buggy or misconfigured servers) causes `get_expiration_datetime` to crash with an `IndexError: string index out of range` instead of raising a clean `ValueError` or returning `None`.

**Root cause:** The guard that detects integer-valued expiration strings (e.g. `'0'` or `'-1'`) accesses `expire_after[0]` without first verifying the string is non-empty:

```python
# Before (crashes with IndexError for expire_after == '')
if (
    isinstance(expire_after, str)
    and (expire_after[1:] if expire_after[0] == '-' else expire_after).isdigit()
):
```

**Fix:** Add `and expire_after` to guard the index access. An empty string then falls through to the existing `_parse_http_date` path, which raises `ValueError('Invalid HTTP date: ')` — consistent with how other invalid date strings are handled.

```python
# After
if (
    isinstance(expire_after, str)
    and expire_after
    and (expire_after[1:] if expire_after[0] == '-' else expire_after).isdigit()
):
```

## Test plan

- Added `test_get_expiration_datetime__empty_string` to `tests/unit/policy/test_expiration.py`
- All existing tests continue to pass

This pull request was prepared with the assistance of AI, under my direction and review.