### PR TITLE
Misc bugfixes for DynamoDB, Redis, and Filesystem backends

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,7 @@
 * Fix bug with SQLite `vacuum()` not freeing disc space
 * Fix error when receiving an empty `Expires` header value
 * Fix DynamoDB item enumeration when the table exceeds 1MB
+* Fix Redis `ttl_offset` for items that should have no expiry
 
 ## 1.3.2 (2026-05-10)
 * Update `CachedResponse` for compatibility with requests 2.34

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@
 ## 1.3.3 (Unreleased)
 * Fix bug with SQLite `vacuum()` not freeing disc space
 * Fix error when receiving an empty `Expires` header value
+* Fix DynamoDB item enumeration when the table exceeds 1MB
 
 ## 1.3.2 (2026-05-10)
 * Update `CachedResponse` for compatibility with requests 2.34

--- a/requests_cache/backends/dynamodb.py
+++ b/requests_cache/backends/dynamodb.py
@@ -145,12 +145,18 @@ class DynamoDbDict(BaseStorage):
 
     def __iter__(self):
         # Alias 'key' attribute since it's a reserved keyword
-        results = self._table.scan(
-            ProjectionExpression='#k',
-            ExpressionAttributeNames={'#k': 'key'},
-        )
-        for item in results['Items']:
-            yield item['key']
+        scan_kwargs: dict = {
+            'ProjectionExpression': '#k',
+            'ExpressionAttributeNames': {'#k': 'key'},
+        }
+        while True:
+            results = self._table.scan(**scan_kwargs)
+            for item in results['Items']:
+                yield item['key']
+            last_key = results.get('LastEvaluatedKey')
+            if not last_key:
+                break
+            scan_kwargs['ExclusiveStartKey'] = last_key
 
     def __len__(self):
         """Get the number of items in the table.
@@ -174,7 +180,13 @@ class DynamoDbDict(BaseStorage):
         serialized_value = value.value if isinstance(value, Binary) else value
         return super().deserialize(key, serialized_value)
 
-    # TODO: Support pagination
     def values(self):
-        for item in self._table.scan()['Items']:
-            yield self.deserialize(item['key'], item['value'])
+        scan_kwargs: dict = {}
+        while True:
+            results = self._table.scan(**scan_kwargs)
+            for item in results['Items']:
+                yield self.deserialize(item['key'], item['value'])
+            last_key = results.get('LastEvaluatedKey')
+            if not last_key:
+                break
+            scan_kwargs['ExclusiveStartKey'] = last_key

--- a/requests_cache/backends/filesystem.py
+++ b/requests_cache/backends/filesystem.py
@@ -83,8 +83,8 @@ class FileCache(BaseCache):
     def clear(self):
         """Clear the cache"""
         # FileDict.clear() removes the cache directory, including redirects.sqlite
-        self.responses.clear()
         with self.lock:
+            self.responses.clear()
             self.redirects.init_db()
 
     def delete(self, *args, **kwargs):

--- a/requests_cache/backends/redis.py
+++ b/requests_cache/backends/redis.py
@@ -92,11 +92,12 @@ class RedisDict(BaseStorage):
     def __setitem__(self, key, item):
         """Save an item to the cache, optionally with TTL"""
         expires_delta = getattr(item, 'expires_delta', None)
-        ttl_seconds = (expires_delta or 0) + self.ttl_offset
-        if self.ttl and ttl_seconds > 0:
-            self.connection.setex(self._bkey(key), ttl_seconds, self.serialize(item))
-        else:
-            self.connection.set(self._bkey(key), self.serialize(item))
+        if expires_delta is not None:
+            ttl_seconds = expires_delta + self.ttl_offset
+            if self.ttl and ttl_seconds > 0:
+                self.connection.setex(self._bkey(key), ttl_seconds, self.serialize(item))
+                return
+        self.connection.set(self._bkey(key), self.serialize(item))
 
     def __delitem__(self, key):
         if not self.connection.delete(self._bkey(key)):

--- a/tests/integration/test_dynamodb.py
+++ b/tests/integration/test_dynamodb.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 from decimal import Decimal
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -8,6 +8,7 @@ from requests_cache.backends import DynamoDbCache, DynamoDbDict
 from tests.conftest import CACHE_NAME, fail_if_no_connection
 from tests.integration.base_cache_test import BaseCacheTest
 from tests.integration.base_storage_test import BaseStorageTest
+
 
 AWS_OPTIONS = {
     'endpoint_url': 'http://localhost:8000',
@@ -92,6 +93,49 @@ class TestDynamoDbDict(BaseStorageTest):
             assert isinstance(ttl_value, Decimal)
         else:
             assert ttl_value is None
+
+    def test_iter_empty_table(self):
+        cache = self.init_cache()
+        cache._table.scan = MagicMock(return_value=_scan_page([]))
+        assert list(cache) == []
+
+    @pytest.mark.parametrize('use_values', [False, True], ids=['__iter__', 'values'])
+    def test_pagination_all_pages_returned(self, use_values):
+        cache = self.init_cache()
+        cache.deserialize = lambda key, value: value
+        cache._table.scan = MagicMock(
+            side_effect=[
+                _scan_page(['a', 'b'], last_key='b'),
+                _scan_page(['c', 'd'], last_key='d'),
+                _scan_page(['e']),
+            ]
+        )
+
+        result = list(cache.values() if use_values else cache)
+
+        assert result == ['a', 'b', 'c', 'd', 'e']
+        assert cache._table.scan.call_count == 3
+
+    def test_pagination_exclusive_start_key_threaded(self):
+        cache = self.init_cache()
+        cache._table.scan = MagicMock(
+            side_effect=[
+                _scan_page(['a'], last_key='a'),
+                _scan_page(['b']),
+            ]
+        )
+
+        list(cache)
+
+        assert 'ExclusiveStartKey' not in cache._table.scan.call_args_list[0].kwargs
+        assert cache._table.scan.call_args_list[1].kwargs['ExclusiveStartKey'] == {'key': 'a'}
+
+
+def _scan_page(keys: list, last_key=None) -> dict:
+    page: dict = {'Items': [{'key': k, 'value': k} for k in keys]}
+    if last_key is not None:
+        page['LastEvaluatedKey'] = {'key': last_key}
+    return page
 
 
 class TestDynamoDbCache(BaseCacheTest):

--- a/tests/integration/test_redis.py
+++ b/tests/integration/test_redis.py
@@ -64,3 +64,12 @@ class TestRedisCache(BaseCacheTest):
         session.get(httpbin('get'))
         mock_setex.assert_not_called()
         mock_set.assert_called()
+
+    @patch.object(StrictRedis, 'setex')
+    @patch.object(StrictRedis, 'set')
+    def test_ttl__no_expiry(self, mock_set, mock_setex):
+        """Items with no expiry should use SET (no TTL) even when ttl_offset is configured"""
+        session = self.init_session(ttl_offset=500)
+        session.get(httpbin('get'))
+        mock_setex.assert_not_called()
+        mock_set.assert_called()


### PR DESCRIPTION
* Fix DynamoDb Pagination for `__iter__` and `values()`
* Fix Redis `ttl_offset` for items that should have no expiry
* Run both steps of `FileCache.clear()` within RLock to fix (unlikely) race condition